### PR TITLE
Made some fixs in whitebrod and dashboard 

### DIFF
--- a/.agents/skills/cognee-quickstart/SKILL.md
+++ b/.agents/skills/cognee-quickstart/SKILL.md
@@ -155,24 +155,24 @@ Create `.env` from `.env.template` if it exists, then set at least `LLM_API_KEY`
 
 When setup fails, do not reinstall blindly. Read the first meaningful error and match it:
 
-| Error clue | Likely fix |
-|---|---|
-| `No module named cognee` | Activate the virtual environment and install `cognee` in that environment. |
-| `Python 3.9`, `SyntaxError`, or resolver rejects Python | Switch to Python 3.10 through 3.14 and recreate the virtual environment. |
-| `anthropic` | Install `cognee[anthropic]`. |
-| `psycopg2`, `asyncpg`, or `pgvector` | Install `cognee[postgres]` or `cognee[postgres-binary]`. |
-| `neo4j` | Install `cognee[neo4j]`. |
-| `playwright`, `tavily`, or `beautifulsoup4` | Install `cognee[scraping]`. |
-| `unstructured` | Install `cognee[docs]`. |
-| `docling` | Install `cognee[docling]`. |
-| `fastembed` | Install `cognee[fastembed]` or `cognee[codegraph]`. |
-| `tree_sitter` | Install `cognee[codegraph]`. |
-| `modal` | Install `cognee[distributed]`. |
-| `redis` | Install `cognee[redis]`. |
-| `baml` | Install `cognee[baml]`. |
-| API key, auth, or provider fallback errors | Confirm `.env` is in the project root and both LLM and embedding settings are configured for non-default providers. |
-| Embedding dimension mismatch or stale vector collections | Reset local metadata with `await cognee.prune.prune_system(metadata=True)` or use a new `SYSTEM_ROOT_DIRECTORY`. |
-| LLM connection preflight times out on a local/small model | Add `COGNEE_SKIP_CONNECTION_TEST=true` to `.env`, then test with a small input. |
+| Error clue                                                | Likely fix                                                                                                          |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `No module named cognee`                                  | Activate the virtual environment and install `cognee` in that environment.                                          |
+| `Python 3.9`, `SyntaxError`, or resolver rejects Python   | Switch to Python 3.10 through 3.14 and recreate the virtual environment.                                            |
+| `anthropic`                                               | Install `cognee[anthropic]`.                                                                                        |
+| `psycopg2`, `asyncpg`, or `pgvector`                      | Install `cognee[postgres]` or `cognee[postgres-binary]`.                                                            |
+| `neo4j`                                                   | Install `cognee[neo4j]`.                                                                                            |
+| `playwright`, `tavily`, or `beautifulsoup4`               | Install `cognee[scraping]`.                                                                                         |
+| `unstructured`                                            | Install `cognee[docs]`.                                                                                             |
+| `docling`                                                 | Install `cognee[docling]`.                                                                                          |
+| `fastembed`                                               | Install `cognee[fastembed]` or `cognee[codegraph]`.                                                                 |
+| `tree_sitter`                                             | Install `cognee[codegraph]`.                                                                                        |
+| `modal`                                                   | Install `cognee[distributed]`.                                                                                      |
+| `redis`                                                   | Install `cognee[redis]`.                                                                                            |
+| `baml`                                                    | Install `cognee[baml]`.                                                                                             |
+| API key, auth, or provider fallback errors                | Confirm `.env` is in the project root and both LLM and embedding settings are configured for non-default providers. |
+| Embedding dimension mismatch or stale vector collections  | Reset local metadata with `await cognee.prune.prune_system(metadata=True)` or use a new `SYSTEM_ROOT_DIRECTORY`.    |
+| LLM connection preflight times out on a local/small model | Add `COGNEE_SKIP_CONNECTION_TEST=true` to `.env`, then test with a small input.                                     |
 
 ## Windows adjustments
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -47,4 +47,10 @@ app.get("/", (c) => {
   return c.text("OK");
 });
 
-export default app;
+export default {
+  // GitHub's OAuth token exchange can take >10s on slow networks; Bun's default
+  // 10s idleTimeout aborts it mid-flight, so the retried callback reuses an
+  // already-consumed code and fails with `bad_verification_code`.
+  idleTimeout: 30,
+  fetch: app.fetch,
+};

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -256,7 +256,7 @@ export default function DashboardPage() {
         project: project.name,
         updated: project.source === "guest" ? "Local draft" : "Saved",
         status: project.source === "guest" ? "Guest" : "Synced",
-        kind: "diagram",
+        kind: project.files[0]?.kind ?? "diagram",
       })),
     [projects],
   );
@@ -352,6 +352,12 @@ export default function DashboardPage() {
     const project = selectedProject;
     const name = fileName.trim();
     if (!project || !name) return;
+
+    if (project.source === "guest") {
+      setFileModalProjectId(null);
+      setProjectError("Log in to save your project before adding files.");
+      return;
+    }
 
     setProjectPending(true);
     setProjectError(null);

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,13 +2,15 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowRight,
   ChevronDown,
   FileText,
   Import,
+  LogIn,
   LogOut,
+  Pencil,
   PenTool,
   Plus,
   Search,
@@ -26,8 +28,12 @@ import {
 import {
   createProject,
   createProjectFile,
+  listProjectFiles,
   listProjects,
+  updateProject,
+  updateProjectFile,
   type SavedProject,
+  type SavedProjectFile,
 } from "@/lib/projects-client";
 import {
   DropdownMenu,
@@ -41,7 +47,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 type FileKind = "diagram" | "doc";
 
 type ProjectFile = {
-  id: string;
+  key: string;
+  projectId: string;
+  fileId: string | null;
   name: string;
   kind: FileKind;
 };
@@ -58,7 +66,8 @@ type Project = {
 
 type RecentFile = {
   id: string;
-  fileId: string;
+  projectId: string;
+  fileId: string | null;
   title: string;
   type: string;
   description: string;
@@ -127,6 +136,13 @@ export default function DashboardPage() {
   const [savedProjectsLoaded, setSavedProjectsLoaded] = useState(false);
   const [signOutPending, setSignOutPending] = useState(false);
   const [projectError, setProjectError] = useState<string | null>(null);
+  const [filesByProject, setFilesByProject] = useState<Record<string, SavedProjectFile[]>>({});
+  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
+  const [editingFileKey, setEditingFileKey] = useState<string | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+  const [expandedProjectId, setExpandedProjectId] = useState<string | null>(null);
+  const skipCommitRef = useRef(false);
+  const expandInitRef = useRef(false);
 
   const user = session.data?.user;
   const isSignedIn = Boolean(user);
@@ -149,8 +165,22 @@ export default function DashboardPage() {
 
       try {
         const projects = await listProjects();
+        if (!active) return;
+        setSavedProjects(projects);
+
+        // Load each project's files so real names show and can be renamed +
+        // created from the dashboard.
+        const entries = await Promise.all(
+          projects.map(async (project) => {
+            try {
+              return [project.id, await listProjectFiles(project.id)] as const;
+            } catch {
+              return [project.id, []] as const;
+            }
+          }),
+        );
         if (active) {
-          setSavedProjects(projects);
+          setFilesByProject(Object.fromEntries(entries));
         }
       } catch (err) {
         if (active) {
@@ -178,29 +208,46 @@ export default function DashboardPage() {
   const projects = useMemo<Project[]>(() => {
     const sourceProjects = isSignedIn ? savedProjects : guestDrafts;
 
-    return sourceProjects.map((project, index) => ({
-      id: project.id,
-      name: project.name,
-      initials: getInitials(project.name),
-      color: getProjectColor(project.name),
-      active: index === 0,
-      source: isSignedIn ? "saved" : "guest",
-      files: [
-        {
-          id: project.id,
-          name: "Your first design",
-          kind: "diagram",
-        },
-      ],
-    }));
-  }, [guestDrafts, isSignedIn, savedProjects]);
+    return sourceProjects.map((project, index) => {
+      const realFiles = isSignedIn ? (filesByProject[project.id] ?? []) : [];
+      const files: ProjectFile[] =
+        realFiles.length > 0
+          ? realFiles.map((file) => ({
+              key: file.id,
+              projectId: project.id,
+              fileId: file.id,
+              name: file.name,
+              kind: file.type === "diagram" ? "diagram" : "doc",
+            }))
+          : [
+              {
+                key: project.id,
+                projectId: project.id,
+                fileId: null,
+                name: "Your first design",
+                kind: "diagram",
+              },
+            ];
+
+      return {
+        id: project.id,
+        name: project.name,
+        initials: getInitials(project.name),
+        color: getProjectColor(project.name),
+        active: index === 0,
+        source: isSignedIn ? "saved" : "guest",
+        files,
+      };
+    });
+  }, [filesByProject, guestDrafts, isSignedIn, savedProjects]);
 
   const recentFiles = useMemo<RecentFile[]>(
     () =>
       projects.map((project) => ({
         id: `recent-${project.id}`,
-        fileId: project.id,
-        title: "Your first design",
+        projectId: project.id,
+        fileId: project.files[0]?.fileId ?? null,
+        title: project.files[0]?.name ?? "Your first design",
         type: "Diagram file",
         description:
           project.source === "guest"
@@ -213,6 +260,13 @@ export default function DashboardPage() {
       })),
     [projects],
   );
+
+  // Open the first project by default; after that, expansion is user-controlled.
+  useEffect(() => {
+    if (expandInitRef.current || projects.length === 0) return;
+    expandInitRef.current = true;
+    setExpandedProjectId(projects[0].id);
+  }, [projects]);
 
   const selectedProject = projects.find((project) => project.id === fileModalProjectId);
   const projectsLoading =
@@ -268,6 +322,11 @@ export default function DashboardPage() {
         return;
       }
 
+      if (guestDrafts.length >= 1) {
+        setProjectError("You can try one project as a guest. Log in to save it and create more.");
+        return;
+      }
+
       const draft = createGuestProjectDraft(name);
       saveGuestProjectDraft(draft);
       setGuestDrafts((currentDrafts) => [draft, ...currentDrafts]);
@@ -287,24 +346,121 @@ export default function DashboardPage() {
     setFileKind("diagram");
   }
 
-  function createFile(event: React.FormEvent<HTMLFormElement>) {
+  async function createFile(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const project = selectedProject;
-    if (!project || !fileName.trim()) return;
+    const name = fileName.trim();
+    if (!project || !name) return;
 
-    if (fileKind === "diagram") {
-      router.push(`/workspace/${project.id}`);
+    setProjectPending(true);
+    setProjectError(null);
+
+    try {
+      const file = await createProjectFile(project.id, {
+        name,
+        type: fileKind === "diagram" ? "diagram" : "doc",
+      });
+      setFilesByProject((current) => ({
+        ...current,
+        [project.id]: [...(current[project.id] ?? []), file],
+      }));
+      setExpandedProjectId(project.id);
+      setFileModalProjectId(null);
+      setFileName("");
+
+      if (fileKind === "diagram") {
+        router.push(`/workspace/${project.id}?file=${file.id}`);
+      }
+    } catch (err) {
+      setProjectError(err instanceof Error ? err.message : "Could not create file.");
+    } finally {
+      setProjectPending(false);
     }
-
-    setFileModalProjectId(null);
-    setFileName("");
   }
 
-  function openFile(file: Pick<ProjectFile, "id" | "kind">) {
+  function openFile(file: Pick<ProjectFile, "projectId" | "fileId" | "kind">) {
     if (file.kind !== "diagram") return;
 
-    router.push(`/workspace/${file.id}`);
+    const query = file.fileId ? `?file=${file.fileId}` : "";
+    router.push(`/workspace/${file.projectId}${query}`);
+  }
+
+  function toggleExpand(id: string) {
+    setExpandedProjectId((current) => (current === id ? null : id));
+  }
+
+  function beginEditProject(project: Project) {
+    setEditingFileKey(null);
+    setEditingProjectId(project.id);
+    setNameDraft(project.name);
+  }
+
+  function beginEditFile(file: ProjectFile) {
+    setEditingProjectId(null);
+    setEditingFileKey(file.key);
+    setNameDraft(file.name);
+  }
+
+  function cancelEdit() {
+    skipCommitRef.current = true;
+    setEditingProjectId(null);
+    setEditingFileKey(null);
+  }
+
+  async function commitProject(project: Project) {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      setEditingProjectId(null);
+      return;
+    }
+    setEditingProjectId(null);
+
+    const name = nameDraft.trim();
+    if (!name || name === project.name) return;
+
+    try {
+      if (project.source === "saved") {
+        const updated = await updateProject(project.id, { name });
+        setSavedProjects((current) =>
+          current.map((p) => (p.id === project.id ? { ...p, name: updated.name } : p)),
+        );
+      } else {
+        const target = guestDrafts.find((entry) => entry.id === project.id);
+        if (target) {
+          const next = { ...target, name };
+          saveGuestProjectDraft(next);
+          setGuestDrafts((current) => current.map((d) => (d.id === project.id ? next : d)));
+        }
+      }
+    } catch (err) {
+      setProjectError(err instanceof Error ? err.message : "Could not rename project.");
+    }
+  }
+
+  async function commitFile(file: ProjectFile) {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      setEditingFileKey(null);
+      return;
+    }
+    setEditingFileKey(null);
+
+    const name = nameDraft.trim();
+    const fileId = file.fileId;
+    if (!name || !fileId || name === file.name) return;
+
+    try {
+      const updated = await updateProjectFile(file.projectId, fileId, { name });
+      setFilesByProject((current) => ({
+        ...current,
+        [file.projectId]: (current[file.projectId] ?? []).map((entry) =>
+          entry.id === fileId ? { ...entry, name: updated.name } : entry,
+        ),
+      }));
+    } catch (err) {
+      setProjectError(err instanceof Error ? err.message : "Could not rename file.");
+    }
   }
 
   return (
@@ -342,14 +498,23 @@ export default function DashboardPage() {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-40">
                 <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    disabled={!isSignedIn || signOutPending}
-                    onSelect={() => void signOut()}
-                    className="cursor-pointer text-od-ink"
-                  >
-                    <LogOut className="h-4 w-4" />
-                    {signOutPending ? "Logging out..." : "Log out"}
-                  </DropdownMenuItem>
+                  {isSignedIn ? (
+                    <DropdownMenuItem
+                      disabled={signOutPending}
+                      onSelect={() => void signOut()}
+                      className="cursor-pointer text-od-ink"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      {signOutPending ? "Logging out..." : "Log out"}
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem asChild className="cursor-pointer text-od-ink">
+                      <Link href="/login">
+                        <LogIn className="h-4 w-4" />
+                        Log in
+                      </Link>
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -390,51 +555,123 @@ export default function DashboardPage() {
                 </button>
               ) : (
                 projects.map((project) => (
-                  <div key={project.id} className="group/project mb-2">
-                    <button
-                      type="button"
-                      onClick={() => router.push(`/workspace/${project.id}`)}
-                      className={`group flex w-full items-center gap-2 rounded-[8px] px-2 py-2 text-left text-[14px] transition ${
+                  <div key={project.id} className="mb-1">
+                    <div
+                      className={`group/prow flex w-full items-center gap-2 rounded-[8px] px-2 py-2 text-[14px] transition ${
                         project.active
                           ? "bg-od-canvas/70 text-od-ink"
                           : "text-od-ink-muted hover:bg-od-canvas/45"
                       }`}
                     >
                       <span
-                        className="grid h-5 w-5 place-items-center rounded-[5px] text-[10px] font-semibold text-white"
+                        className="grid h-5 w-5 shrink-0 place-items-center rounded-[5px] text-[10px] font-semibold text-white"
                         style={{ backgroundColor: project.color }}
                       >
                         {project.initials}
                       </span>
-                      <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                      <ChevronDown className="h-3.5 w-3.5 text-od-ink-faint" />
-                    </button>
-
-                    <div className="mt-1 grid gap-0.5 pl-5">
-                      {project.files.map(({ id, name, kind }) => {
-                        const Icon = getFileIcon(kind);
-
-                        return (
+                      {editingProjectId === project.id ? (
+                        <input
+                          autoFocus
+                          value={nameDraft}
+                          onChange={(event) => setNameDraft(event.target.value)}
+                          onBlur={() => void commitProject(project)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") event.currentTarget.blur();
+                            else if (event.key === "Escape") cancelEdit();
+                          }}
+                          className="min-w-0 flex-1 rounded-[5px] border border-od-border-soft bg-white px-1.5 py-0.5 text-[13px] text-od-ink outline-none focus:border-od-ink"
+                        />
+                      ) : (
+                        <>
                           <button
-                            key={id}
                             type="button"
-                            onClick={() => openFile({ id, kind })}
-                            className="flex h-7 cursor-pointer items-center gap-2 rounded-[7px] px-2 text-left text-[12px] text-od-ink-muted transition hover:bg-od-canvas/45 hover:text-od-ink"
+                            onClick={() => router.push(`/workspace/${project.id}`)}
+                            className="min-w-0 flex-1 cursor-pointer truncate text-left"
                           >
-                            <Icon className="h-3.5 w-3.5 shrink-0 text-od-ink-faint" />
-                            <span className="min-w-0 truncate">{name}</span>
+                            {project.name}
                           </button>
-                        );
-                      })}
-                      <button
-                        type="button"
-                        onClick={() => openFileModal(project.id)}
-                        className="flex h-7 items-center gap-2 rounded-[7px] px-2 text-left text-[12px] text-od-ink-faint opacity-0 transition hover:bg-od-canvas/45 hover:text-od-ink group-hover/project:opacity-100"
-                      >
-                        <Plus className="h-3.5 w-3.5 shrink-0" />
-                        <span className="min-w-0 truncate">New file</span>
-                      </button>
+                          <button
+                            type="button"
+                            onClick={() => beginEditProject(project)}
+                            aria-label="Rename project"
+                            className="grid h-6 w-6 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint opacity-0 transition hover:bg-od-canvas/60 hover:text-od-ink group-hover/prow:opacity-100"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => toggleExpand(project.id)}
+                            aria-label={expandedProjectId === project.id ? "Collapse" : "Expand"}
+                            aria-expanded={expandedProjectId === project.id}
+                            className="grid h-6 w-6 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint transition hover:bg-od-canvas/60 hover:text-od-ink"
+                          >
+                            <ChevronDown
+                              className={`h-3.5 w-3.5 transition-transform ${
+                                expandedProjectId === project.id ? "" : "-rotate-90"
+                              }`}
+                            />
+                          </button>
+                        </>
+                      )}
                     </div>
+
+                    {expandedProjectId === project.id && (
+                      <div className="mt-1 grid gap-0.5 pl-5">
+                        {project.files.map((file) => {
+                          const Icon = getFileIcon(file.kind);
+
+                          return (
+                            <div
+                              key={file.key}
+                              className="group/file flex h-7 items-center gap-2 rounded-[7px] px-2 text-[12px] text-od-ink-muted transition hover:bg-od-canvas/45 hover:text-od-ink"
+                            >
+                              <Icon className="h-3.5 w-3.5 shrink-0 text-od-ink-faint" />
+                              {editingFileKey === file.key ? (
+                                <input
+                                  autoFocus
+                                  value={nameDraft}
+                                  onChange={(event) => setNameDraft(event.target.value)}
+                                  onBlur={() => void commitFile(file)}
+                                  onKeyDown={(event) => {
+                                    if (event.key === "Enter") event.currentTarget.blur();
+                                    else if (event.key === "Escape") cancelEdit();
+                                  }}
+                                  className="min-w-0 flex-1 rounded-[5px] border border-od-border-soft bg-white px-1.5 py-0.5 text-[12px] text-od-ink outline-none focus:border-od-ink"
+                                />
+                              ) : (
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={() => openFile(file)}
+                                    className="min-w-0 flex-1 cursor-pointer truncate text-left"
+                                  >
+                                    {file.name}
+                                  </button>
+                                  {file.fileId && (
+                                    <button
+                                      type="button"
+                                      onClick={() => beginEditFile(file)}
+                                      aria-label="Rename file"
+                                      className="grid h-5 w-5 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint opacity-0 transition hover:bg-od-canvas/60 hover:text-od-ink group-hover/file:opacity-100"
+                                    >
+                                      <Pencil className="h-3 w-3" />
+                                    </button>
+                                  )}
+                                </>
+                              )}
+                            </div>
+                          );
+                        })}
+                        <button
+                          type="button"
+                          onClick={() => openFileModal(project.id)}
+                          className="flex h-7 items-center gap-2 rounded-[7px] px-2 text-left text-[12px] text-od-ink-faint transition hover:bg-od-canvas/45 hover:text-od-ink"
+                        >
+                          <Plus className="h-3.5 w-3.5 shrink-0" />
+                          <span className="min-w-0 truncate">New file</span>
+                        </button>
+                      </div>
+                    )}
                   </div>
                 ))
               )}
@@ -568,6 +805,7 @@ export default function DashboardPage() {
                     {recentFiles.map(
                       ({
                         id,
+                        projectId,
                         fileId,
                         title,
                         type,
@@ -583,7 +821,7 @@ export default function DashboardPage() {
                           <button
                             key={id}
                             type="button"
-                            onClick={() => openFile({ id: fileId, kind })}
+                            onClick={() => openFile({ projectId, fileId, kind })}
                             className="group grid w-full cursor-pointer grid-cols-[auto_1fr] gap-3 p-4 text-left transition hover:bg-od-surface-elevated md:grid-cols-[auto_1fr_150px_100px] md:items-center md:p-5"
                           >
                             <span className="grid h-10 w-10 place-items-center rounded-[8px] border border-od-border-soft bg-od-surface-elevated text-od-ink transition group-hover:scale-105">

--- a/apps/web/src/app/import/github/page.tsx
+++ b/apps/web/src/app/import/github/page.tsx
@@ -106,7 +106,6 @@ function GitHubImportContent() {
     try {
       await authClient.signIn.social({
         provider: "github",
-        scopes: ["repo"],
         callbackURL: new URL(callbackPath, window.location.origin).toString(),
       });
     } catch {

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { AuthForm } from "@/components/auth/auth-form";
 export default function LoginPage() {
   return (
     <main className="grid min-h-dvh place-items-center bg-od-canvas px-4 py-12">
-      <Suspense>
+      <Suspense fallback={<div className="text-[13px] text-od-ink-faint">Loading…</div>}>
         <AuthForm mode="login" />
       </Suspense>
     </main>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+import { AuthForm } from "@/components/auth/auth-form";
+
+export default function LoginPage() {
+  return (
+    <main className="grid min-h-dvh place-items-center bg-od-canvas px-4 py-12">
+      <Suspense>
+        <AuthForm mode="login" />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -4,7 +4,7 @@ import { AuthForm } from "@/components/auth/auth-form";
 export default function SignupPage() {
   return (
     <main className="grid min-h-dvh place-items-center bg-od-canvas px-4 py-12">
-      <Suspense>
+      <Suspense fallback={<div className="text-[13px] text-od-ink-faint">Loading…</div>}>
         <AuthForm mode="signup" />
       </Suspense>
     </main>

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+import { AuthForm } from "@/components/auth/auth-form";
+
+export default function SignupPage() {
+  return (
+    <main className="grid min-h-dvh place-items-center bg-od-canvas px-4 py-12">
+      <Suspense>
+        <AuthForm mode="signup" />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/app/workspace/[projectId]/page.tsx
+++ b/apps/web/src/app/workspace/[projectId]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { WorkspaceLayout } from "@/components/whiteboard/WorkspaceLayout";
 
 interface WorkspacePageProps {
@@ -9,7 +10,9 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
 
   return (
     <div className="h-screen w-screen overflow-hidden">
-      <WorkspaceLayout />
+      <Suspense>
+        <WorkspaceLayout />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/auth/auth-form.tsx
+++ b/apps/web/src/components/auth/auth-form.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+function GithubMark() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" className="h-4 w-4">
+      <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58l-.01-2.05c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.12-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22l-.01 3.29c0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
+    </svg>
+  );
+}
+
+export function AuthForm({ mode }: { mode: "login" | "signup" }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const redirectTo = params.get("redirect") || "/dashboard";
+  const isSignup = mode === "signup";
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [pending, setPending] = useState(false);
+  const [githubPending, setGithubPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+
+    const { error: authError } = isSignup
+      ? await authClient.signUp.email({ name, email, password })
+      : await authClient.signIn.email({ email, password });
+
+    if (authError) {
+      setError(authError.message || "Something went wrong. Please try again.");
+      setPending(false);
+      return;
+    }
+
+    router.push(redirectTo);
+    router.refresh();
+  }
+
+  async function onGithub() {
+    setGithubPending(true);
+    setError(null);
+    try {
+      await authClient.signIn.social({ provider: "github", callbackURL: redirectTo });
+    } catch {
+      setError("Could not start GitHub sign in.");
+      setGithubPending(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-[400px] rounded-[16px] border border-od-border-soft bg-od-surface p-6 shadow-[0_24px_80px_-40px_rgba(0,0,0,0.55)]">
+      <div className="mb-6 flex flex-col gap-1">
+        <h1 className="text-[22px] font-semibold text-od-ink">
+          {isSignup ? "Create your account" : "Welcome back"}
+        </h1>
+        <p className="text-[13px] text-od-ink-muted">
+          {isSignup
+            ? "Save your diagrams to your workspace."
+            : "Log in to access your saved projects."}
+        </p>
+      </div>
+
+      <form onSubmit={onSubmit} className="grid gap-3">
+        {isSignup && (
+          <label className="grid gap-1.5 text-[13px] font-medium text-od-ink-muted">
+            Name
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Ada Lovelace"
+              required
+              autoComplete="name"
+            />
+          </label>
+        )}
+        <label className="grid gap-1.5 text-[13px] font-medium text-od-ink-muted">
+          Email
+          <Input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="you@example.com"
+            required
+            autoComplete="email"
+          />
+        </label>
+        <label className="grid gap-1.5 text-[13px] font-medium text-od-ink-muted">
+          Password
+          <Input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="At least 8 characters"
+            required
+            minLength={8}
+            autoComplete={isSignup ? "new-password" : "current-password"}
+          />
+        </label>
+
+        {error && <p className="text-[13px] text-red-600">{error}</p>}
+
+        <Button
+          type="submit"
+          disabled={pending}
+          className="mt-1 cursor-pointer disabled:cursor-wait"
+        >
+          {pending ? "Please wait..." : isSignup ? "Create account" : "Sign in"}
+        </Button>
+      </form>
+
+      <div className="my-4 flex items-center gap-3 text-[12px] text-od-ink-faint">
+        <span className="h-px flex-1 bg-od-border-soft" />
+        or
+        <span className="h-px flex-1 bg-od-border-soft" />
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onGithub}
+        disabled={githubPending}
+        className="w-full cursor-pointer disabled:cursor-wait"
+      >
+        <GithubMark />
+        {githubPending ? "Opening GitHub..." : "Continue with GitHub"}
+      </Button>
+
+      <p className="mt-6 text-center text-[13px] text-od-ink-muted">
+        {isSignup ? "Already have an account? " : "New to OpenDiagram? "}
+        <Link
+          href={isSignup ? "/login" : "/signup"}
+          className="font-medium text-od-ink underline-offset-4 hover:underline"
+        >
+          {isSignup ? "Log in" : "Create one"}
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/auth-form.tsx
+++ b/apps/web/src/components/auth/auth-form.tsx
@@ -15,11 +15,24 @@ function GithubMark() {
   );
 }
 
+// Only allow internal, non-protocol-relative paths so a crafted
+// `?redirect=` can't bounce the user to an external site after login.
+function safeRedirect(raw: string | null): string {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) {
+    return "/dashboard";
+  }
+  return raw;
+}
+
 export function AuthForm({ mode }: { mode: "login" | "signup" }) {
   const router = useRouter();
   const params = useSearchParams();
-  const redirectTo = params.get("redirect") || "/dashboard";
+  const redirectParam = params.get("redirect");
+  const redirectTo = safeRedirect(redirectParam);
   const isSignup = mode === "signup";
+  const switchHref =
+    `${isSignup ? "/login" : "/signup"}` +
+    (redirectParam ? `?redirect=${encodeURIComponent(redirectTo)}` : "");
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -51,7 +64,14 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
     setGithubPending(true);
     setError(null);
     try {
-      await authClient.signIn.social({ provider: "github", callbackURL: redirectTo });
+      // Absolute URLs on THIS (web) origin -- better-auth resolves relative
+      // callbackURLs against the server's baseURL, which sends users to the API
+      // origin (:3000) instead of the web app in a split deployment.
+      await authClient.signIn.social({
+        provider: "github",
+        callbackURL: `${window.location.origin}${redirectTo}`,
+        errorCallbackURL: `${window.location.origin}/login`,
+      });
     } catch {
       setError("Could not start GitHub sign in.");
       setGithubPending(false);
@@ -139,7 +159,7 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
       <p className="mt-6 text-center text-[13px] text-od-ink-muted">
         {isSignup ? "Already have an account? " : "New to OpenDiagram? "}
         <Link
-          href={isSignup ? "/login" : "/signup"}
+          href={switchHref}
           className="font-medium text-od-ink underline-offset-4 hover:underline"
         >
           {isSignup ? "Log in" : "Create one"}

--- a/apps/web/src/components/auth/auth-form.tsx
+++ b/apps/web/src/components/auth/auth-form.tsx
@@ -67,10 +67,13 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
       // Absolute URLs on THIS (web) origin -- better-auth resolves relative
       // callbackURLs against the server's baseURL, which sends users to the API
       // origin (:3000) instead of the web app in a split deployment.
+      const errorCallbackURL =
+        `${window.location.origin}/login` +
+        (redirectParam ? `?redirect=${encodeURIComponent(redirectTo)}` : "");
       await authClient.signIn.social({
         provider: "github",
         callbackURL: `${window.location.origin}${redirectTo}`,
-        errorCallbackURL: `${window.location.origin}/login`,
+        errorCallbackURL,
       });
     } catch {
       setError("Could not start GitHub sign in.");

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -146,7 +146,6 @@ export function HeroSection() {
     try {
       await authClient.signIn.social({
         provider: "github",
-        scopes: ["repo"],
         callbackURL,
       });
     } catch {

--- a/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
+++ b/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { env } from "@OpenDiagram/env/web";
 import { AIChatPanel } from "./AIChatPanel";
 import { Whiteboard } from "./Whiteboard";
 import { authClient } from "@/lib/auth-client";
@@ -15,10 +16,15 @@ import {
 import {
   createProject,
   createProjectFile,
+  getProjectFile,
   listProjectFiles,
   updateProjectFile,
   type SavedProjectFile,
 } from "@/lib/projects-client";
+
+const AUTOSAVE_DELAY_MS = 800;
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 function sanitizeSceneAppState(appState: unknown) {
   if (!appState || typeof appState !== "object") return appState;
@@ -28,30 +34,72 @@ function sanitizeSceneAppState(appState: unknown) {
   return rest;
 }
 
+// Cheap change signal (sum of element `version`s, same idea as Excalidraw's
+// getSceneVersion). Excalidraw fires onChange on every render — without this we
+// autosave in an infinite loop even when the drawing hasn't actually changed.
+function sceneElementsVersion(elements: readonly unknown[]) {
+  let version = 0;
+  for (const element of elements) {
+    if (element && typeof element === "object" && "version" in element) {
+      const value = (element as { version?: unknown }).version;
+      if (typeof value === "number") version += value;
+    }
+  }
+  return version;
+}
+
+function initialElementsVersion(scene: unknown) {
+  const elements = (scene as { elements?: unknown })?.elements;
+  return Array.isArray(elements) ? sceneElementsVersion(elements) : 0;
+}
+
 export function WorkspaceLayout() {
   const params = useParams<{ projectId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fileIdParam = searchParams.get("file");
   const session = authClient.useSession();
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null);
   const [draft, setDraft] = useState<GuestProjectDraft | null>(null);
   const [activeFile, setActiveFile] = useState<SavedProjectFile | null>(null);
   const [initialScene, setInitialScene] = useState<unknown>(null);
   const [leavePromptOpen, setLeavePromptOpen] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState("");
   const [savePending, setSavePending] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const draftRef = useRef<GuestProjectDraft | null>(null);
   const sceneRef = useRef<unknown>(null);
+  const activeFileRef = useRef<SavedProjectFile | null>(null);
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dirtyRef = useRef(false);
+  const promotionStartedRef = useRef(false);
+  const lastSavedVersionRef = useRef(0);
+  const pendingVersionRef = useRef(0);
+  const skipCommitRef = useRef(false);
+
+  const isSignedIn = Boolean(session.data?.user);
+  // Kept in a ref so the (frequently called) Excalidraw onChange handler reads
+  // the latest auth state without being re-created on every render.
+  const isSignedInRef = useRef(isSignedIn);
+  isSignedInRef.current = isSignedIn;
+
+  useEffect(() => {
+    activeFileRef.current = activeFile;
+  }, [activeFile]);
 
   useEffect(() => {
     const nextDraft = getGuestProjectDraft(params.projectId);
     draftRef.current = nextDraft;
     setDraft(nextDraft);
     setInitialScene(nextDraft?.scene ?? null);
+    lastSavedVersionRef.current = initialElementsVersion(nextDraft?.scene);
   }, [params.projectId]);
 
+  // Guest hard-exit guard (tab close / refresh).
   useEffect(() => {
-    if (!draft || session.data?.user) return;
+    if (!draft || isSignedIn) return;
 
     function warnBeforeUnload(event: BeforeUnloadEvent) {
       event.preventDefault();
@@ -61,10 +109,27 @@ export function WorkspaceLayout() {
     window.addEventListener("beforeunload", warnBeforeUnload);
 
     return () => window.removeEventListener("beforeunload", warnBeforeUnload);
-  }, [draft, session.data?.user]);
+  }, [draft, isSignedIn]);
+
+  // Guest in-app back-navigation guard: intercept the browser back button and
+  // show the "you'll lose your work" prompt instead of silently leaving.
+  useEffect(() => {
+    if (!draft || isSignedIn) return;
+
+    window.history.pushState(null, "", window.location.href);
+
+    function onPopState() {
+      window.history.pushState(null, "", window.location.href);
+      setLeavePromptOpen(true);
+    }
+
+    window.addEventListener("popstate", onPopState);
+
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [draft, isSignedIn]);
 
   useEffect(() => {
-    if (session.isPending || !session.data?.user || draftRef.current) return;
+    if (session.isPending || !isSignedIn || draftRef.current) return;
 
     let active = true;
 
@@ -73,18 +138,23 @@ export function WorkspaceLayout() {
 
       try {
         const files = await listProjectFiles(params.projectId);
-        const diagramFile = files.find((file) => file.type === "diagram");
-        const file =
-          diagramFile ??
-          (await createProjectFile(params.projectId, {
-            name: "Your first design",
-            type: "diagram",
-          }));
+        const target =
+          (fileIdParam ? files.find((file) => file.id === fileIdParam) : undefined) ??
+          files.find((file) => file.type === "diagram");
+        // The list endpoint omits `scene`; fetch the full file so the canvas
+        // reloads its saved content (or create the first diagram file).
+        const diagramFile = target
+          ? await getProjectFile(params.projectId, target.id)
+          : await createProjectFile(params.projectId, {
+              name: "Your first design",
+              type: "diagram",
+            });
 
         if (active) {
-          setActiveFile(file);
-          sceneRef.current = file.scene ?? null;
-          setInitialScene(file.scene ?? null);
+          setActiveFile(diagramFile);
+          sceneRef.current = diagramFile.scene ?? null;
+          setInitialScene(diagramFile.scene ?? null);
+          lastSavedVersionRef.current = initialElementsVersion(diagramFile.scene);
         }
       } catch (err) {
         if (active) {
@@ -98,16 +168,11 @@ export function WorkspaceLayout() {
     return () => {
       active = false;
     };
-  }, [draft, params.projectId, session.data?.user, session.isPending]);
+  }, [draft, fileIdParam, params.projectId, isSignedIn, session.isPending]);
 
   const saveDraftAfterLogin = useCallback(async () => {
     const currentDraft = draftRef.current;
-    if (!currentDraft) return;
-
-    if (!session.data?.user) {
-      setLeavePromptOpen(true);
-      return;
-    }
+    if (!currentDraft || !session.data?.user) return;
 
     setSavePending(true);
     setSaveError(null);
@@ -135,30 +200,92 @@ export function WorkspaceLayout() {
     }
   }, [router, session.data?.user]);
 
+  // After a guest returns signed-in, promote their local draft to a saved project.
   useEffect(() => {
-    if (!draft || !session.data?.user || savePending) return;
+    if (!draft || !session.data?.user || savePending || promotionStartedRef.current) return;
 
+    promotionStartedRef.current = true;
     void saveDraftAfterLogin();
   }, [draft, saveDraftAfterLogin, savePending, session.data?.user]);
 
-  const updateGuestDraft = useCallback(
-    (elements: readonly unknown[], appState: unknown, files: unknown) => {
-      const scene = { elements, appState: sanitizeSceneAppState(appState), files };
+  const runAutosave = useCallback(async () => {
+    const file = activeFileRef.current;
+    if (!file) return;
 
+    const versionAtSave = pendingVersionRef.current;
+
+    try {
+      await updateProjectFile(params.projectId, file.id, { scene: sceneRef.current });
+      lastSavedVersionRef.current = versionAtSave;
+      dirtyRef.current = false;
+      setSaveStatus("saved");
+    } catch {
+      setSaveStatus("error");
+    }
+  }, [params.projectId]);
+
+  const scheduleAutosave = useCallback(() => {
+    dirtyRef.current = true;
+    setSaveStatus("saving");
+
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = setTimeout(() => void runAutosave(), AUTOSAVE_DELAY_MS);
+  }, [runAutosave]);
+
+  const handleSceneChange = useCallback(
+    (elements: readonly unknown[], appState: unknown, files: unknown) => {
+      // Ignore onChange fires that don't actually change the drawing (Excalidraw
+      // emits on every render); otherwise autosave loops forever.
+      const version = sceneElementsVersion(elements);
+      if (version === lastSavedVersionRef.current) return;
+
+      const scene = { elements, appState: sanitizeSceneAppState(appState), files };
       sceneRef.current = scene;
 
       const currentDraft = draftRef.current;
-      if (!currentDraft || session.data?.user) return;
+      if (currentDraft && !isSignedInRef.current) {
+        lastSavedVersionRef.current = version;
+        draftRef.current = { ...currentDraft, scene };
+        saveGuestProjectDraft(draftRef.current);
+        return;
+      }
 
-      const nextDraft = {
-        ...currentDraft,
-        scene,
-      };
-
-      draftRef.current = nextDraft;
-      saveGuestProjectDraft(nextDraft);
+      if (isSignedInRef.current && activeFileRef.current) {
+        pendingVersionRef.current = version;
+        scheduleAutosave();
+      }
     },
-    [session.data?.user],
+    [scheduleAutosave],
+  );
+
+  // Flush pending edits on tab-close / navigate so nothing in the debounce
+  // window is lost (keepalive lets the request outlive the page).
+  useEffect(() => {
+    function flush() {
+      if (!isSignedInRef.current || !dirtyRef.current) return;
+
+      const file = activeFileRef.current;
+      if (!file) return;
+
+      fetch(`${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${params.projectId}/files/${file.id}`, {
+        method: "PATCH",
+        credentials: "include",
+        keepalive: true,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scene: sceneRef.current }),
+      }).catch(() => {});
+    }
+
+    window.addEventListener("pagehide", flush);
+
+    return () => window.removeEventListener("pagehide", flush);
+  }, [params.projectId]);
+
+  useEffect(
+    () => () => {
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    },
+    [],
   );
 
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
@@ -181,42 +308,73 @@ export function WorkspaceLayout() {
     }
   }, [excalidrawAPI, initialScene]);
 
-  async function saveActiveFile() {
-    if (!session.data?.user) {
-      await saveDraftAfterLogin();
+  function goToLogin() {
+    const redirect = encodeURIComponent(window.location.pathname);
+    router.push(`/login?redirect=${redirect}`);
+  }
+
+  // Inline rename of the file name (tap the title to edit). Project name is not
+  // editable here — that lives on the dashboard.
+  function beginEditName() {
+    setNameDraft(activeFile?.name ?? draft?.name ?? "Your first design");
+    setIsEditingName(true);
+  }
+
+  function cancelName() {
+    skipCommitRef.current = true;
+    setIsEditingName(false);
+  }
+
+  async function commitName() {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      setIsEditingName(false);
+      return;
+    }
+    setIsEditingName(false);
+
+    const name = nameDraft.trim();
+    if (!name) return;
+
+    const currentDraft = draftRef.current;
+    if (currentDraft && !isSignedIn) {
+      if (name === currentDraft.name) return;
+      const nextDraft = { ...currentDraft, name };
+      draftRef.current = nextDraft;
+      saveGuestProjectDraft(nextDraft);
+      setDraft(nextDraft);
       return;
     }
 
-    if (!activeFile) {
-      setSaveError("Project file is still loading.");
-      return;
-    }
-
-    setSavePending(true);
-    setSaveError(null);
-    setSaveMessage(null);
-
-    try {
-      const file = await updateProjectFile(params.projectId, activeFile.id, {
-        scene: sceneRef.current,
-      });
-
-      setActiveFile(file);
-      setSaveMessage("Saved");
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Could not save canvas.");
-    } finally {
-      setSavePending(false);
+    if (activeFile && name !== activeFile.name) {
+      try {
+        const updated = await updateProjectFile(params.projectId, activeFile.id, { name });
+        setActiveFile(updated);
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : "Could not rename file.");
+      }
     }
   }
 
-  async function signInToSave() {
-    await authClient.signIn.social({
-      provider: "github",
-      scopes: ["repo"],
-      callbackURL: window.location.href,
-    });
+  function leaveWithoutSaving() {
+    // Guest chose not to sign in — discard the local draft (project + diagram).
+    const currentDraft = draftRef.current;
+    if (currentDraft) {
+      deleteGuestProjectDraft(currentDraft.id);
+      draftRef.current = null;
+      setDraft(null);
+    }
+    setLeavePromptOpen(false);
+    router.push("/dashboard");
   }
+
+  const saveIndicator = !isSignedIn
+    ? { dot: "bg-od-ink-faint", label: "Guest" }
+    : saveStatus === "saving"
+      ? { dot: "bg-amber-500", label: "Saving…" }
+      : saveStatus === "error"
+        ? { dot: "bg-red-500", label: "Save failed" }
+        : { dot: "bg-od-green", label: "Saved" };
 
   return (
     <div className="flex h-full w-full">
@@ -224,54 +382,86 @@ export function WorkspaceLayout() {
         <Whiteboard
           initialScene={initialScene}
           onAPIReady={handleExcalidrawAPI}
-          onSceneChange={updateGuestDraft}
+          onSceneChange={handleSceneChange}
         />
       </div>
-      <div className="w-96 shrink-0">
-        {(draft || session.data?.user) && (
-          <div className="border-b border-od-border-soft bg-white p-3">
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <p className="truncate text-[13px] font-medium text-od-ink">
-                  {draft?.name ?? activeFile?.name ?? "Your first design"}
-                </p>
-                <p className="truncate text-[12px] text-od-ink-faint">
-                  {session.data?.user ? "Saved project file" : "Guest draft"}
-                </p>
+      <div className="flex h-full w-96 shrink-0 flex-col">
+        {(draft || isSignedIn) && (
+          <div className="shrink-0 border-b border-od-border-soft bg-white p-3">
+            <div className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
+                {isEditingName ? (
+                  <input
+                    autoFocus
+                    value={nameDraft}
+                    onChange={(event) => setNameDraft(event.target.value)}
+                    onBlur={() => void commitName()}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") event.currentTarget.blur();
+                      else if (event.key === "Escape") cancelName();
+                    }}
+                    className="w-full rounded-[6px] border border-od-border-soft px-1.5 py-1 text-[14px] font-medium text-od-ink outline-none focus:border-od-ink"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={beginEditName}
+                    title="Rename file"
+                    className="-mx-1.5 block max-w-full truncate rounded-[6px] px-1.5 py-1 text-left text-[14px] font-medium text-od-ink transition hover:bg-od-canvas/40"
+                  >
+                    {activeFile?.name ?? draft?.name ?? "Your first design"}
+                  </button>
+                )}
               </div>
-              <button
-                type="button"
-                onClick={saveActiveFile}
-                disabled={savePending}
-                className="h-8 rounded-[8px] bg-od-ink px-3 text-[12px] font-medium text-white disabled:cursor-wait disabled:opacity-70"
+              <span
+                className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-od-ink-faint"
+                title={saveError ?? undefined}
               >
-                {savePending ? "Saving..." : "Save"}
-              </button>
+                <span className={`h-1.5 w-1.5 rounded-full ${saveIndicator.dot}`} />
+                {saveIndicator.label}
+              </span>
+              {!isSignedIn && (
+                <button
+                  type="button"
+                  onClick={goToLogin}
+                  className="h-8 shrink-0 rounded-[8px] bg-od-ink px-3 text-[12px] font-medium text-white"
+                >
+                  Sign in to save
+                </button>
+              )}
             </div>
-            {saveMessage && <p className="mt-2 text-[12px] text-od-green">{saveMessage}</p>}
-            {saveError && <p className="mt-2 text-[12px] text-red-600">{saveError}</p>}
+            {saveError && <p className="mt-1.5 truncate text-[11px] text-red-600">{saveError}</p>}
           </div>
         )}
-        <AIChatPanel excalidrawAPI={excalidrawAPI} />
+        <div className="min-h-0 flex-1">
+          <AIChatPanel excalidrawAPI={excalidrawAPI} />
+        </div>
       </div>
       {leavePromptOpen && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/25 px-4">
-          <div className="w-full max-w-[420px] rounded-[18px] border border-od-border-soft bg-white p-5 shadow-[0_24px_80px_-40px_rgba(0,0,0,0.55)]">
+        <div
+          className="fixed inset-0 z-50 grid place-items-center bg-black/25 px-4"
+          onClick={() => setLeavePromptOpen(false)}
+        >
+          <div
+            className="w-full max-w-[420px] rounded-[18px] border border-od-border-soft bg-white p-5 shadow-[0_24px_80px_-40px_rgba(0,0,0,0.55)]"
+            onClick={(event) => event.stopPropagation()}
+          >
             <h2 className="text-[18px] font-semibold text-od-ink">You&apos;ll lose your work</h2>
             <p className="mt-2 text-[14px] leading-6 text-od-ink-muted">
-              Sign in to save this guest draft to your workspace before leaving.
+              This project is only on this device. Sign in to save it to your workspace, or leave to
+              discard it.
             </p>
-            <div className="mt-5 flex justify-end gap-2">
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
               <button
                 type="button"
-                onClick={() => setLeavePromptOpen(false)}
-                className="h-10 rounded-[8px] border border-od-border-soft px-4 text-[14px] font-medium text-od-ink"
+                onClick={leaveWithoutSaving}
+                className="h-10 rounded-[8px] border border-od-border-soft px-4 text-[14px] font-medium text-od-ink-muted hover:text-od-ink"
               >
-                Keep editing
+                Leave without saving
               </button>
               <button
                 type="button"
-                onClick={signInToSave}
+                onClick={goToLogin}
                 className="h-10 rounded-[8px] bg-od-ink px-4 text-[14px] font-medium text-white"
               >
                 Login / Sign up

--- a/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
+++ b/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
@@ -217,7 +217,9 @@ export function WorkspaceLayout() {
     try {
       await updateProjectFile(params.projectId, file.id, { scene: sceneRef.current });
       lastSavedVersionRef.current = versionAtSave;
-      dirtyRef.current = false;
+      // Only clear dirty if no newer edit landed while this save was in flight,
+      // otherwise a pagehide flush would skip the newer unsaved scene.
+      if (versionAtSave === pendingVersionRef.current) dirtyRef.current = false;
       setSaveStatus("saved");
     } catch {
       setSaveStatus("error");
@@ -309,7 +311,7 @@ export function WorkspaceLayout() {
   }, [excalidrawAPI, initialScene]);
 
   function goToLogin() {
-    const redirect = encodeURIComponent(window.location.pathname);
+    const redirect = encodeURIComponent(window.location.pathname + window.location.search);
     router.push(`/login?redirect=${redirect}`);
   }
 
@@ -430,7 +432,20 @@ export function WorkspaceLayout() {
                 </button>
               )}
             </div>
-            {saveError && <p className="mt-1.5 truncate text-[11px] text-red-600">{saveError}</p>}
+            {saveError && (
+              <div className="mt-1.5 flex items-center gap-2">
+                <p className="min-w-0 flex-1 truncate text-[11px] text-red-600">{saveError}</p>
+                {isSignedIn && draft && !savePending && (
+                  <button
+                    type="button"
+                    onClick={() => void saveDraftAfterLogin()}
+                    className="shrink-0 rounded-[6px] border border-od-border-soft px-2 py-0.5 text-[11px] font-medium text-od-ink hover:bg-od-canvas/40"
+                  >
+                    Retry save
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
         <div className="min-h-0 flex-1">

--- a/apps/web/src/lib/guest-drafts.ts
+++ b/apps/web/src/lib/guest-drafts.ts
@@ -51,7 +51,8 @@ export function listGuestProjectDrafts(): GuestProjectDraft[] {
         const parsed = JSON.parse(raw);
         if (typeof parsed !== "object" || parsed === null) return null;
         if (typeof parsed.id !== "string" || typeof parsed.name !== "string") return null;
-        if (typeof parsed.createdAt !== "string" || typeof parsed.updatedAt !== "string") return null;
+        if (typeof parsed.createdAt !== "string" || typeof parsed.updatedAt !== "string")
+          return null;
         return parsed as GuestProjectDraft;
       } catch {
         return null;

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -90,6 +90,25 @@ export async function createProject(input: CreateProjectInput): Promise<SavedPro
   return data.project;
 }
 
+export async function updateProject(
+  id: string,
+  input: { name?: string; description?: string | null },
+): Promise<SavedProject> {
+  const response = await fetch(`${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${id}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const data = await readProjectResponse(response);
+
+  if (!response.ok) {
+    throw new Error(data?.error ?? "Could not rename project.");
+  }
+
+  return data.project;
+}
+
 export async function listProjectFiles(projectId: string): Promise<SavedProjectFile[]> {
   const response = await fetch(`${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files`, {
     credentials: "include",
@@ -101,6 +120,20 @@ export async function listProjectFiles(projectId: string): Promise<SavedProjectF
   }
 
   return data.files;
+}
+
+export async function getProjectFile(projectId: string, fileId: string): Promise<SavedProjectFile> {
+  const response = await fetch(
+    `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${fileId}`,
+    { credentials: "include" },
+  );
+  const data = await readProjectResponse(response);
+
+  if (!response.ok) {
+    throw new Error(data?.error ?? "Could not load project file.");
+  }
+
+  return data.file;
 }
 
 export async function createProjectFile(

--- a/bun.lock
+++ b/bun.lock
@@ -811,17 +811,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-guuiO2kKc7yUQFU2jhWyM/BrYGD/brqb0+JvJIXTQ/QI1NlWfHZ1id50kkkOWqxmBiDc8DgW2orfY85pQIc7gw=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UglEDl/r1/h5Vw6oS6cEE29Jugz2sDLxHCSupNznKatj1fDMRXFqYKFcbvm8RTFhtYPI45NxkrPNo9BqNychBg=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.2", "", { "os": "linux", "cpu": "x64" }, "sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.3", "", { "os": "linux", "cpu": "x64" }, "sha512-KuQxaPWD7OBmwEZqO0sgijwcuXR5eMWbo7BEt2m1D2Q3RylJDj7WMcJ0Btv2VJA0QC+khzAaTAm1yWowJ0CWAw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-DPkIKQ+6p0sho3Cx/e/A3F+AKgXQJA+z//cHsTcyyM1YWRGSYA0UTP8NUpb4iS2tVBSniGwmjRUr73hpq8kcDg=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.2", "", { "os": "win32", "cpu": "x64" }, "sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.3", "", { "os": "win32", "cpu": "x64" }, "sha512-8NvFAze9D4PsosZAnK3aGqHz2vLzREz9lNIxLgfE0jRchq2sZQE190cwFm7WX17yg3ftPvwCvWH3rhLbG1UHCQ=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-AqjqV5cHbFa0YRaQ+Dyw6lSm6as4h/Uf8LcZ7VN8i+Odr23ShFD5SUvVAR1d3rZqibFVs9c0VdtXdfQfkdcs3A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -925,21 +925,21 @@
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260703.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260703.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260703.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-qyEHkEeRWCSGLa6a8oArnMPdn3Vcl1AZj8YHLO7lK0VjEEF/YJfz1FvxmpEeuhy0ZDfvJ7GtgXbvbjcU3zpPjQ=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260704.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260704.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260704.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-B8CxdI0CumQVV9/9COcanWCWJmu8Jm1kMuYvse3iGm5ay9QrKTD+qyb11x8SPKUMtiUqnhNxt0n4ESNt+LQMuQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260703.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EwJEd6hfaHrrbSLat6+xX8fZiAvG+/Ae1gqvJEayTNdDbkrZxmeLS23YdjUmDMIOKI2wa7zXQDid8WtrvDfMTQ=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260704.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WHNMx8HTka+2w9ZifYbfkHHyQBzO+MCbOLQzNJE3K7A7mYJ1aq6ZEvBhRcNqixjKAIIO4U34KQvaQ6PXlwezkQ=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260703.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-tcS3gpivMq+BAiaupFqM5vuERykogJlfD4CjoxkSCksmmsKgWV96S2U/LjrKgll8R6/OEkg2VL2ycRG9+tIuHw=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260704.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-IZJib4da/+3gRVSQFoQU1uFzsiSXnI02xBZljipDoPwahRcOdjH9gJ7DMBFbZ53pUtN5lvqbpES4oXiJZTneDA=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "arm" }, "sha512-nluwnKcdGo6laWWYtWF3zFUDfi7nNrcD5S/T5382fVmtKmNqIdzFm9ANgSSGAavuzfdu9YJLaVWpx72Oe40AEQ=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Dkz8oqvg4nEIu2Acz/d+iBDhIIOqjaAJ6mo6a2diRrDI+K5NAHljTzvkclCxgz6WIa5JnUY3kWzy8jE5AtaCQg=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-m8IJTOneLXRtq6prLz8uuhp463kEt+AHV5Ceqp7G0o3eAvbKP059OwzK6WXCS5J0B3ZxX+BwBf9wDXSNidWJCw=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rjyHYAmDQ68NZIpU5i46D50hgQ63UJGGN/LJv3DAPWC8KraNonS5j4fN2bH/V+acQV9l/sS3+US1daV8VkQaFQ=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5ga94rso68kaxJUzaufDVhka1zPaSbPgNXaemQO8faPW0crvRIkbv0g8bpG4pdWMV0tTylmluDles4ZcAzOprg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "x64" }, "sha512-y2L2eNwCgrTgXKMol9n/bSPeyNHwJbrUDAv6/J7/087yhPNCt61l3KbpiGAYs0KYcCt3V2lNSDtS3geHQfSWJQ=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260703.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YeRqOUuSyhbtryBSUE073OLpReIQXWJVyjP45gPLJ+0KAGvkd1VFz2FY1JEo++LyHoqXsGD2+qvdPpnTfSAIJg=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260704.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-PzBVRs8UNSAqtoCp9BtT1jsG4SSOfuDT1yo8Z3gGevmNtKEFZjb92BTSnBZaMPPQkM22fq83zgrAEVOEENIicw=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260703.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WYNcbTaxCPgiDLrL2aPJ3BJA05nJU8DK0fUFGkGAER0oM+KcJcQUBeUkXg/7A4HBTNYcj7zIxqNgkJU1TRa/Kw=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260704.1", "", { "os": "win32", "cpu": "x64" }, "sha512-wb/C+fqWpXAoJZd8KQZdpjOq67v/cmLsApjL9oHjC1X6zqz7AzyOQ486uxWT6LvYzKkar4A+iq8h5h+PNgN38w=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
@@ -1219,7 +1219,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.385", "", {}, "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.387", "", {}, "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -1417,7 +1417,7 @@
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1435,7 +1435,7 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
-    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -2049,7 +2049,7 @@
 
     "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
 
-    "systeminformation": ["systeminformation@5.31.11", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-I6O7iaUj23AXRgCPDDnvi3xHvdOLp4+1YMbF+X194lJwY1NeWojgHJPhslVKcmTtrLTguRk3QJK+xEdTiI3P0w=="],
+    "systeminformation": ["systeminformation@5.31.12", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-qnTtO5wHrKeKE/MvQ6iIt6XAV+5fgt/kPIQf27DYgjVQQuHUfWkV4Gu6k04ZpEzAMuyQ3ZsovY7Ivhp+E9JyWw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
@@ -2087,11 +2087,11 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.22.5", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ=="],
+    "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
 
     "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
-    "turbo": ["turbo@2.10.2", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.2", "@turbo/darwin-arm64": "2.10.2", "@turbo/linux-64": "2.10.2", "@turbo/linux-arm64": "2.10.2", "@turbo/windows-64": "2.10.2", "@turbo/windows-arm64": "2.10.2" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ=="],
+    "turbo": ["turbo@2.10.3", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.3", "@turbo/darwin-arm64": "2.10.3", "@turbo/linux-64": "2.10.3", "@turbo/linux-arm64": "2.10.3", "@turbo/windows-64": "2.10.3", "@turbo/windows-arm64": "2.10.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
@@ -2359,7 +2359,7 @@
 
     "sass/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "server/ai": ["ai@7.0.14", "", { "dependencies": { "@ai-sdk/gateway": "4.0.11", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qA82fZyD4xh9IDB+s3SvwbjwjR+GGRmJjTYMwON1uROj8vPDIQbPTZLLq6ZWTVESn9daeH1GMv0zKfVLwNU2sQ=="],
+    "server/ai": ["ai@7.0.15", "", { "dependencies": { "@ai-sdk/gateway": "4.0.12", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -2369,11 +2369,11 @@
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "web/@ai-sdk/react": ["@ai-sdk/react@4.0.15", "", { "dependencies": { "@ai-sdk/mcp": "2.0.7", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "ai": "7.0.14", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-JN95NNG8m/OnAdOTtl3YbB0QnAp1IY8Yxrgh8ue+d95HsBKu079R+uq+b8pFt3MtGpjmY93OPgDZq1j33SOrhQ=="],
+    "web/@ai-sdk/react": ["@ai-sdk/react@4.0.16", "", { "dependencies": { "@ai-sdk/mcp": "2.0.7", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "ai": "7.0.15", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-VpJhn9ob7EC9g2Wn5m/FCCu8h6Uj4tE7u8BunK0kNo5kJasEl/f3oHV7f3r4tNtq4zW5wu0EjGs5sKkShErGew=="],
 
     "web/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 
-    "web/ai": ["ai@7.0.14", "", { "dependencies": { "@ai-sdk/gateway": "4.0.11", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qA82fZyD4xh9IDB+s3SvwbjwjR+GGRmJjTYMwON1uROj8vPDIQbPTZLLq6ZWTVESn9daeH1GMv0zKfVLwNU2sQ=="],
+    "web/ai": ["ai@7.0.15", "", { "dependencies": { "@ai-sdk/gateway": "4.0.12", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
@@ -2535,6 +2535,8 @@
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -2597,7 +2599,7 @@
 
     "sass/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
-    "server/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZdZzQnBxYfjJpWpSNkV+rRWycwTBhxyvwGvxcwx9g+WQoy3MK2xNahSySEgP9hD/X2xY9jkjd0xB67oDE3rLMA=="],
+    "server/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA=="],
 
     "server/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
 
@@ -2661,7 +2663,7 @@
 
     "web/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "web/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZdZzQnBxYfjJpWpSNkV+rRWycwTBhxyvwGvxcwx9g+WQoy3MK2xNahSySEgP9hD/X2xY9jkjd0xB67oDE3rLMA=="],
+    "web/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA=="],
 
     "web/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -27,10 +27,22 @@ export function createAuth() {
     emailAndPassword: {
       enabled: true,
     },
+    // Stateless OAuth state: keep the whole state payload in one encrypted,
+    // short-lived cookie instead of the DB. Avoids "verification not found"
+    // from flaky pooler writes / `bun --hot` reloads mid-flow.
+    account: {
+      storeStateStrategy: "cookie",
+    },
     socialProviders: githubProvider,
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     advanced: {
+      // In prod, web (app.vyse.site) and server (api.vyse.site) are different
+      // subdomains, so the session cookie must be scoped to the shared parent
+      // domain or the browser treats it as third-party and drops it.
+      ...(env.COOKIE_DOMAIN
+        ? { crossSubDomainCookies: { enabled: true, domain: env.COOKIE_DOMAIN } }
+        : {}),
       defaultCookieAttributes: {
         sameSite: "none",
         secure: true,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,12 +4,6 @@ import { env } from "@OpenDiagram/env/server";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
-// TODO: Replace with Redis-backed secondary storage before deploying to production.
-// The current in-memory Map does not survive across server instances or cold starts,
-// which will break OAuth flows and rate limiting in horizontally scaled deployments.
-// See https://www.better-auth.com/docs/advanced/secondary-storage
-const secondaryStorage = createMemorySecondaryStorage();
-
 export function createAuth() {
   const db = createDb();
   const githubProvider =
@@ -18,7 +12,7 @@ export function createAuth() {
           github: {
             clientId: env.GITHUB_CLIENT_ID,
             clientSecret: env.GITHUB_CLIENT_SECRET,
-            scopes: ["user:email", "repo"],
+            scopes: ["read:user", "user:email"],
           },
         }
       : undefined;
@@ -30,10 +24,6 @@ export function createAuth() {
       schema: schema,
     }),
     trustedOrigins: [env.CORS_ORIGIN],
-    secondaryStorage,
-    session: {
-      storeSessionInDatabase: true,
-    },
     emailAndPassword: {
       enabled: true,
     },
@@ -52,58 +42,3 @@ export function createAuth() {
 }
 
 export const auth = createAuth();
-
-function createMemorySecondaryStorage() {
-  const store = new Map<string, { value: string; expiresAt: number | null }>();
-
-  let sweepTimer: ReturnType<typeof setInterval> | null = null;
-
-  function sweep() {
-    const now = Date.now();
-    for (const [key, entry] of store) {
-      if (entry.expiresAt && entry.expiresAt <= now) {
-        store.delete(key);
-      }
-    }
-  }
-
-  function read(key: string) {
-    const entry = store.get(key);
-
-    if (!entry) return null;
-
-    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
-      store.delete(key);
-      return null;
-    }
-
-    return entry.value;
-  }
-
-  return {
-    async get(key: string) {
-      return read(key);
-    },
-    async set(key: string, value: string, ttl?: number) {
-      store.set(key, {
-        value,
-        expiresAt: ttl ? Date.now() + ttl * 1000 : null,
-      });
-
-      if (!sweepTimer) {
-        sweepTimer = setInterval(sweep, 60_000);
-        if (typeof sweepTimer === "object" && "unref" in sweepTimer) {
-          sweepTimer.unref();
-        }
-      }
-    },
-    async delete(key: string) {
-      store.delete(key);
-    },
-    async getAndDelete(key: string) {
-      const value = read(key);
-      store.delete(key);
-      return value;
-    },
-  };
-}

--- a/packages/db/src/migrations/0001_sticky_mole_man.sql
+++ b/packages/db/src/migrations/0001_sticky_mole_man.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "project_file" (
+	"id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"type" text NOT NULL,
+	"name" text NOT NULL,
+	"scene" jsonb,
+	"spec" jsonb,
+	"content" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "project_file" ADD CONSTRAINT "project_file_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "project_file_projectId_idx" ON "project_file" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "project_file_type_idx" ON "project_file" USING btree ("type");

--- a/packages/db/src/migrations/meta/0001_snapshot.json
+++ b/packages/db/src/migrations/meta/0001_snapshot.json
@@ -1,0 +1,561 @@
+{
+  "id": "4208924f-2225-4f1e-852d-0e7aa1f7d7fb",
+  "prevId": "156076b5-2874-4498-8a42-36172829bbb5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_userId_idx": {
+          "name": "project_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_user_id_user_id_fk": {
+          "name": "project_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file": {
+      "name": "project_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_projectId_idx": {
+          "name": "project_file_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_type_idx": {
+          "name": "project_file_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_project_id_fk": {
+          "name": "project_file_project_id_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783076934350,
       "tag": "0000_nice_crusher_hogan",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783164377923,
+      "tag": "0001_sticky_mole_man",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -10,6 +10,10 @@ export const env = createEnv({
     CORS_ORIGIN: z.url(),
     GITHUB_CLIENT_ID: z.string().min(1).optional(),
     GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
+    // Prod split deploy: set to the shared parent domain (e.g. ".vyse.site") so
+    // the session cookie is shared across app.* (web) and api.* (server). Leave
+    // unset locally -- localhost needs no cross-subdomain sharing.
+    COOKIE_DOMAIN: z.string().min(1).optional(),
     GOOGLE_GENERATIVE_AI_API_KEY: z.string().min(1),
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds multi-file projects with inline rename and whiteboard autosave, plus email/password auth. Hardens sign-in with read-only GitHub scopes, stateless OAuth cookie state, web-origin callbacks with a dynamic errorCallbackURL, safer redirects, and fixes rare GitHub token timeouts.

- New Features
  - Multi-file projects: list, expand/collapse, create, and rename files from the dashboard; open a specific file via ?file=<id>.
  - Inline rename: edit project and file names in the dashboard; edit the active file name in the whiteboard header.
  - Whiteboard autosave: signed-in users get debounced autosave with keepalive on tab close and a clear save status; guests save locally with a leave prompt, “Sign in to save” CTA, one-draft limit, and automatic post-login promotion (with retry).
  - Auth: new /login and /signup (email/password); GitHub OAuth now uses read-only scopes with web-origin callback + dynamic errorCallbackURL, sanitized ?redirect, stateless cookie state, and optional cross-subdomain cookies via `COOKIE_DOMAIN`.
  - Server: extend Bun idleTimeout to 30s to avoid OAuth token exchange timeouts.

- Migration
  - Run the DB migration to add the `project_file` table and indexes.
  - No breaking changes; if a project has no diagram file, one is created on open.
  - Ensure `NEXT_PUBLIC_SERVER_URL` is set for autosave; in split deploys set `COOKIE_DOMAIN` to share cookies across app.* and api.*.
  - Review your GitHub OAuth app; `repo` scope is no longer required.

<sup>Written for commit c5b5cd9225d74da8be2a648c44d19fef4f749b92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

