### PR TITLE
seo + quota limits

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import { diagramRoute } from "./routes/diagram";
 import { githubImportRoute, githubRoute } from "./routes/github";
 import { orchestrateRoute } from "./routes/orchestrate";
 import { projectsRoute } from "./routes/projects";
+import { usageRoute } from "./routes/usage";
 
 initLogger({
   env: { service: "OpenDiagram-server" },
@@ -40,6 +41,7 @@ app.use(
     origin: origins,
     allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
+    exposeHeaders: ["X-CreationQuota-Limit", "X-CreationQuota-Used", "X-CreationQuota-Remaining"],
     credentials: true,
   }),
 );
@@ -50,6 +52,7 @@ app.route("/api/orchestrate", orchestrateRoute);
 app.route("/api/github", githubRoute);
 app.route("/api/import", githubImportRoute);
 app.route("/api/projects", projectsRoute);
+app.route("/api/usage", usageRoute);
 
 export default {
   // Two slow paths share this: GitHub's OAuth token exchange (>10s on slow

--- a/apps/server/src/lib/creation-quota.ts
+++ b/apps/server/src/lib/creation-quota.ts
@@ -1,0 +1,150 @@
+import { auth } from "@OpenDiagram/auth";
+import { and, db, eq, sql } from "@OpenDiagram/db";
+import { creationUsage } from "@OpenDiagram/db/schema/creation-usage";
+import { env } from "@OpenDiagram/env/server";
+import type { Context } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+
+const GUEST_COOKIE = "opendiagram_guest_id";
+const GUEST_LIMIT = 3;
+const USER_LIMIT = 10;
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 400;
+const BETA_QUOTA_WINDOW_START = new Date(Date.UTC(2026, 6, 1));
+
+export type CreationQuotaActor = {
+  actorType: "guest" | "user";
+  actorId: string;
+  limit: number;
+  windowStart: Date;
+};
+
+export type CreationQuotaSnapshot = {
+  actorType: "guest" | "user";
+  limit: number;
+  used: number;
+  remaining: number;
+  resetAt: null;
+};
+
+export class CreationQuotaExceededError extends Error {
+  snapshot: CreationQuotaSnapshot;
+
+  constructor(snapshot: CreationQuotaSnapshot) {
+    super(
+      snapshot.actorType === "guest"
+        ? "You've used all 3 free beta creation requests. Sign in to get 10 beta requests."
+        : "You've used all 10 beta creation requests.",
+    );
+    this.name = "CreationQuotaExceededError";
+    this.snapshot = snapshot;
+  }
+}
+
+export async function getCreationQuotaActor(
+  c: Context,
+  options: { userId?: string } = {},
+): Promise<CreationQuotaActor> {
+  const session = options.userId
+    ? null
+    : await auth.api.getSession({ headers: c.req.raw.headers }).catch(() => null);
+  const userId = options.userId ?? session?.user.id;
+
+  if (userId) {
+    return {
+      actorType: "user",
+      actorId: userId,
+      limit: USER_LIMIT,
+      windowStart: BETA_QUOTA_WINDOW_START,
+    };
+  }
+
+  let guestId = getCookie(c, GUEST_COOKIE);
+  if (!guestId) {
+    guestId = crypto.randomUUID();
+    setCookie(c, GUEST_COOKIE, guestId, {
+      httpOnly: true,
+      maxAge: COOKIE_MAX_AGE,
+      path: "/",
+      sameSite: "Lax",
+      secure: env.NODE_ENV === "production",
+    });
+  }
+
+  return {
+    actorType: "guest",
+    actorId: guestId,
+    limit: GUEST_LIMIT,
+    windowStart: BETA_QUOTA_WINDOW_START,
+  };
+}
+
+export async function getCreationQuotaSnapshot(
+  actor: CreationQuotaActor,
+): Promise<CreationQuotaSnapshot> {
+  const [row] = await db
+    .select({ count: creationUsage.count })
+    .from(creationUsage)
+    .where(
+      and(
+        eq(creationUsage.actorType, actor.actorType),
+        eq(creationUsage.actorId, actor.actorId),
+        eq(creationUsage.windowStart, actor.windowStart),
+      ),
+    );
+
+  return toSnapshot(actor, row?.count ?? 0);
+}
+
+export async function consumeCreationQuota(actor: CreationQuotaActor) {
+  const [row] = await db
+    .insert(creationUsage)
+    .values({
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      windowStart: actor.windowStart,
+      count: 1,
+    })
+    .onConflictDoUpdate({
+      target: [creationUsage.actorType, creationUsage.actorId, creationUsage.windowStart],
+      set: {
+        count: sql`${creationUsage.count} + 1`,
+        updatedAt: new Date(),
+      },
+      where: sql`${creationUsage.count} < ${actor.limit}`,
+    })
+    .returning({ count: creationUsage.count });
+
+  if (!row) {
+    throw new CreationQuotaExceededError(await getCreationQuotaSnapshot(actor));
+  }
+
+  return toSnapshot(actor, row.count);
+}
+
+export function applyCreationQuotaHeaders(c: Context, snapshot: CreationQuotaSnapshot) {
+  c.header("X-CreationQuota-Limit", String(snapshot.limit));
+  c.header("X-CreationQuota-Used", String(snapshot.used));
+  c.header("X-CreationQuota-Remaining", String(snapshot.remaining));
+}
+
+export function creationQuotaExceededResponse(c: Context, error: CreationQuotaExceededError) {
+  applyCreationQuotaHeaders(c, error.snapshot);
+  return c.json(
+    {
+      error: error.message,
+      code: "creation_quota_exceeded",
+      quota: error.snapshot,
+    },
+    429,
+  );
+}
+
+function toSnapshot(actor: CreationQuotaActor, used: number): CreationQuotaSnapshot {
+  return {
+    actorType: actor.actorType,
+    limit: actor.limit,
+    used,
+    remaining: Math.max(actor.limit - used, 0),
+    resetAt: null,
+  };
+}

--- a/apps/server/src/lib/creation-quota.ts
+++ b/apps/server/src/lib/creation-quota.ts
@@ -31,9 +31,11 @@ export class CreationQuotaExceededError extends Error {
 
   constructor(snapshot: CreationQuotaSnapshot) {
     super(
-      snapshot.actorType === "guest"
-        ? "You've used all 3 free beta creation requests. Sign in to get 10 beta requests."
-        : "You've used all 10 beta creation requests.",
+      snapshot.limit <= 0
+        ? "Beta creation requests are currently unavailable for this account."
+        : snapshot.actorType === "guest"
+          ? `You've used all ${snapshot.limit} free beta creation requests. Sign in to get ${USER_LIMIT} beta requests.`
+          : `You've used all ${snapshot.limit} beta creation requests.`,
     );
     this.name = "CreationQuotaExceededError";
     this.snapshot = snapshot;
@@ -96,6 +98,10 @@ export async function getCreationQuotaSnapshot(
 }
 
 export async function consumeCreationQuota(actor: CreationQuotaActor) {
+  if (actor.limit <= 0) {
+    throw new CreationQuotaExceededError(toSnapshot(actor, 0));
+  }
+
   const [row] = await db
     .insert(creationUsage)
     .values({

--- a/apps/server/src/routes/diagram.ts
+++ b/apps/server/src/routes/diagram.ts
@@ -15,6 +15,13 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { buildSystemPrompt } from "../lib/agent/prompt";
 import { askUserTool, createDrawDiagramTool } from "../lib/agent/tools";
+import {
+  applyCreationQuotaHeaders,
+  consumeCreationQuota,
+  creationQuotaExceededResponse,
+  CreationQuotaExceededError,
+  getCreationQuotaActor,
+} from "../lib/creation-quota";
 import { LLM_MAX_RETRIES } from "../lib/repo-ai";
 
 const google = createGoogle({ apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY });
@@ -80,6 +87,16 @@ diagramRoute.post("/chat", async (c) => {
       { error: "Invalid messages", detail: err instanceof Error ? err.message : String(err) },
       400,
     );
+  }
+
+  try {
+    const quota = await consumeCreationQuota(await getCreationQuotaActor(c));
+    applyCreationQuotaHeaders(c, quota);
+  } catch (error) {
+    if (error instanceof CreationQuotaExceededError) {
+      return creationQuotaExceededResponse(c, error);
+    }
+    throw error;
   }
 
   const tools = {

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -6,6 +6,13 @@ import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import { generateGroundedProjectAnswer } from "../lib/repo-ai";
 import {
+  applyCreationQuotaHeaders,
+  consumeCreationQuota,
+  creationQuotaExceededResponse,
+  CreationQuotaExceededError,
+  getCreationQuotaActor,
+} from "../lib/creation-quota";
+import {
   getProjectMemoryContext,
   getProjectMemoryStatus,
   markProjectMemoryPending,
@@ -196,6 +203,16 @@ projectsRoute.post("/:projectId/chat", async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
+  try {
+    const quota = await consumeCreationQuota(await getCreationQuotaActor(c, { userId }));
+    applyCreationQuotaHeaders(c, quota);
+  } catch (error) {
+    if (error instanceof CreationQuotaExceededError) {
+      return creationQuotaExceededResponse(c, error);
+    }
+    throw error;
+  }
+
   const answer = await generateGroundedProjectAnswer({
     message: parsed.data.message,
     context: projectContext.context,
@@ -211,6 +228,27 @@ projectsRoute.post("/:projectId/chat", async (c) => {
 projectsRoute.post("/:projectId/repo-generation", async (c) => {
   const userId = c.get("userId");
   const projectId = c.req.param("projectId");
+  const [projectRow] = await db
+    .select({ source: project.source, generationStatus: project.generationStatus })
+    .from(project)
+    .where(and(eq(project.id, projectId), eq(project.userId, userId)));
+
+  if (!projectRow) return c.json({ error: "Not found" }, 404);
+  if (projectRow.source !== "github_import") {
+    return c.json({ error: "Repository generation is only available for GitHub imports." }, 400);
+  }
+
+  if (projectRow.generationStatus === "none" || projectRow.generationStatus === "failed") {
+    try {
+      const quota = await consumeCreationQuota(await getCreationQuotaActor(c, { userId }));
+      applyCreationQuotaHeaders(c, quota);
+    } catch (error) {
+      if (error instanceof CreationQuotaExceededError) {
+        return creationQuotaExceededResponse(c, error);
+      }
+      throw error;
+    }
+  }
 
   let started: Awaited<ReturnType<typeof startRepoGeneration>>;
   try {

--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import {
+  applyCreationQuotaHeaders,
+  getCreationQuotaActor,
+  getCreationQuotaSnapshot,
+} from "../lib/creation-quota";
+
+export const usageRoute = new Hono();
+
+usageRoute.get("/creation-quota", async (c) => {
+  const actor = await getCreationQuotaActor(c);
+  const quota = await getCreationQuotaSnapshot(actor);
+  applyCreationQuotaHeaders(c, quota);
+  c.header("Cache-Control", "private, no-store");
+  return c.json({ quota });
+});

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,7 @@
+import { createPrivateMetadata } from "@/lib/site";
+
+export const metadata = createPrivateMetadata("Dashboard");
+
+export default function DashboardLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/apps/web/src/app/import/layout.tsx
+++ b/apps/web/src/app/import/layout.tsx
@@ -1,0 +1,7 @@
+import { createPrivateMetadata } from "@/lib/site";
+
+export const metadata = createPrivateMetadata("Import a repository");
+
+export default function ImportLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, Instrument_Serif } from "next/font/google";
 import "./globals.css";
 import "lenis/dist/lenis.css";
+import { GITHUB_URL, HOME_DESCRIPTION, HOME_TITLE, SITE_NAME, SITE_URL } from "@/lib/site";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -19,9 +20,17 @@ const instrumentSerif = Instrument_Serif({
 });
 
 export const metadata: Metadata = {
-  title: "OpenDiagram",
-  description:
-    "We help open source maintainers generate beautiful, accurate documentation — fast and automatically.",
+  metadataBase: SITE_URL,
+  applicationName: SITE_NAME,
+  title: {
+    default: HOME_TITLE,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: HOME_DESCRIPTION,
+  authors: [{ name: SITE_NAME, url: GITHUB_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  category: "technology",
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/login/layout.tsx
+++ b/apps/web/src/app/login/layout.tsx
@@ -1,0 +1,7 @@
+import { createPrivateMetadata } from "@/lib/site";
+
+export const metadata = createPrivateMetadata("Sign in");
+
+export default function LoginLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,99 @@
+import type { Metadata } from "next";
 import { LandingPage } from "@/components/landing/landing-page";
 import { SmoothScrollProvider } from "@/components/smooth-scroll-provider";
+import { GITHUB_URL, HOME_DESCRIPTION, HOME_TITLE, SITE_NAME, SITE_URL } from "@/lib/site";
+
+const organizationId = new URL("/#organization", SITE_URL).href;
+const websiteId = new URL("/#website", SITE_URL).href;
+const applicationId = new URL("/#software-application", SITE_URL).href;
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": organizationId,
+      name: SITE_NAME,
+      url: SITE_URL.href,
+      logo: new URL("/favicon.ico", SITE_URL).href,
+      sameAs: [GITHUB_URL],
+    },
+    {
+      "@type": "WebSite",
+      "@id": websiteId,
+      name: SITE_NAME,
+      url: SITE_URL.href,
+      description: HOME_DESCRIPTION,
+      publisher: { "@id": organizationId },
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": applicationId,
+      name: SITE_NAME,
+      url: SITE_URL.href,
+      description: HOME_DESCRIPTION,
+      applicationCategory: "DesignApplication",
+      operatingSystem: "Web browser",
+      image: new URL("/od_flower1.jpg", SITE_URL).href,
+      isAccessibleForFree: true,
+      license: `${GITHUB_URL}/blob/main/LICENSE`,
+      author: { "@id": organizationId },
+      sameAs: GITHUB_URL,
+    },
+  ],
+};
+
+export const metadata: Metadata = {
+  title: {
+    absolute: HOME_TITLE,
+  },
+  description: HOME_DESCRIPTION,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: "/",
+    siteName: SITE_NAME,
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    images: [
+      {
+        url: "/od_flower1.jpg",
+        width: 2380,
+        height: 3200,
+        alt: "OpenDiagram artwork combining a flower with connected diagram nodes",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    images: ["/od_flower1.jpg"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};
 
 export default function Home() {
   return (
     <SmoothScrollProvider>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+      />
       <LandingPage />
     </SmoothScrollProvider>
   );

--- a/apps/web/src/app/project/layout.tsx
+++ b/apps/web/src/app/project/layout.tsx
@@ -1,0 +1,7 @@
+import { createPrivateMetadata } from "@/lib/site";
+
+export const metadata = createPrivateMetadata("Project workspace");
+
+export default function ProjectLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: new URL("/sitemap.xml", SITE_URL).href,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -5,6 +5,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: SITE_URL.href,
+      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: SITE_URL.href,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/apps/web/src/components/whiteboard/AIChatPanel.tsx
+++ b/apps/web/src/components/whiteboard/AIChatPanel.tsx
@@ -10,7 +10,12 @@ import { env } from "@OpenDiagram/env/web";
 import type { DiagramSpec, RenderSkeleton, ThemeName } from "@OpenDiagram/harness";
 import { applyDiagramToCanvas } from "@/lib/excalidraw-utils";
 import { orchestrateWorkspaceRequest, runProjectChatAgent } from "@/lib/workspace-agents";
-import { updateProjectFile, type RepoGenerationJob } from "@/lib/projects-client";
+import {
+  CreationQuotaError,
+  updateProjectFile,
+  type CreationQuota,
+  type RepoGenerationJob,
+} from "@/lib/projects-client";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -61,6 +66,25 @@ interface AIChatPanelProps {
   initialHistory?: ChatMessage[];
   repoGenerationJob?: RepoGenerationJob | null;
   repoGenerationError?: string | null;
+  onQuotaError?: (message: string) => void;
+}
+
+async function fetchDiagramChat(input: RequestInfo | URL, init?: RequestInit) {
+  const response = await fetch(input, { ...init, credentials: "include" });
+  if (response.ok) return response;
+
+  const data = (await response.json().catch(() => null)) as {
+    error?: string;
+    code?: string;
+    quota?: CreationQuota;
+  } | null;
+  const message = data?.error ?? "The diagram agent is unavailable. Try again.";
+
+  if (data?.code === "creation_quota_exceeded") {
+    throw new CreationQuotaError(message, data.quota);
+  }
+
+  throw new Error(message);
 }
 
 /** The last assistant message's unanswered ask_user call, if any. */
@@ -117,6 +141,7 @@ export function AIChatPanel({
   initialHistory,
   repoGenerationJob,
   repoGenerationError,
+  onQuotaError,
 }: AIChatPanelProps) {
   const currentSpecRef = useRef<DiagramSpec | undefined>(undefined);
   const frameByTitleRef = useRef(new Map<string, string>());
@@ -144,9 +169,15 @@ export function AIChatPanel({
     transport: new DefaultChatTransport({
       api: `${env.NEXT_PUBLIC_SERVER_URL}/api/diagram/chat`,
       body: () => ({ currentSpec: currentSpecRef.current, theme: themeRef.current }),
+      fetch: fetchDiagramChat,
     }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
+
+  useEffect(() => {
+    if (!(diagramError instanceof CreationQuotaError)) return;
+    onQuotaError?.(diagramError.message);
+  }, [diagramError, onQuotaError]);
 
   // Apply each finished draw_diagram call to the canvas exactly once. If the
   // agent redraws a diagram it already drew (same title), the old frame is
@@ -227,6 +258,7 @@ export function AIChatPanel({
         setProjectStatus("ready");
       } catch (err) {
         const message = err instanceof Error ? err.message : "Project chat failed";
+        if (err instanceof CreationQuotaError) onQuotaError?.(message);
         setProjectMessages((prev) => [
           ...prev,
           { id: `msg-${messageIdRef.current++}`, role: "assistant", text: `Error: ${message}` },
@@ -237,7 +269,7 @@ export function AIChatPanel({
 
       return true;
     },
-    [fileId, projectId],
+    [fileId, onQuotaError, projectId],
   );
 
   const handleSubmit = useCallback(
@@ -362,8 +394,7 @@ export function AIChatPanel({
           )}
           {diagramStatus === "error" && (
             <p className="text-xs text-destructive">
-              Something went wrong{diagramError?.message ? ` — ${diagramError.message}` : ""}. Try
-              again.
+              {diagramError?.message ?? "Something went wrong. Try again."}
             </p>
           )}
           {projectError && <p className="text-xs text-destructive">{projectError}</p>}

--- a/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
+++ b/apps/web/src/components/whiteboard/WorkspaceLayout.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { WorkspaceAgentSidebar } from "./workspace-layout/WorkspaceAgentSidebar";
 import { FirstFileDialog, LeavePromptDialog } from "./workspace-layout/WorkspaceDialogs";
 import { WorkspaceEditorPane } from "./workspace-layout/WorkspaceEditorPane";
@@ -9,6 +17,7 @@ import { useWorkspaceLayoutController } from "./workspace-layout/useWorkspaceLay
 
 export function WorkspaceLayout() {
   const { state, actions } = useWorkspaceLayoutController();
+  const [quotaMessage, setQuotaMessage] = useState<string | null>(null);
   const activeHistory = state.activeFile?.history as
     | { id: string; role: "user" | "assistant"; text: string }[]
     | undefined;
@@ -69,6 +78,7 @@ export function WorkspaceLayout() {
           fileId={agentFileId}
           initialHistory={activeHistory}
           onClose={actions.closeAgent}
+          onQuotaError={setQuotaMessage}
           onResizeStart={actions.handleResizeStart}
           projectId={agentProjectId}
           repoGenerationError={state.repoGenerationError}
@@ -88,6 +98,21 @@ export function WorkspaceLayout() {
         onSignIn={actions.signInToSave}
         open={state.leavePromptOpen}
       />
+      <Dialog
+        open={quotaMessage !== null}
+        onOpenChange={(open) => {
+          if (!open) setQuotaMessage(null);
+        }}
+      >
+        <DialogContent className="border-od-border-soft bg-white sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-od-ink">Beta creation limit reached</DialogTitle>
+            <DialogDescription className="leading-6 text-od-ink-muted">
+              {quotaMessage}
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/components/whiteboard/workspace-layout/WorkspaceAgentSidebar.tsx
+++ b/apps/web/src/components/whiteboard/workspace-layout/WorkspaceAgentSidebar.tsx
@@ -13,6 +13,7 @@ type WorkspaceAgentSidebarProps = {
   projectId?: string;
   repoGenerationError: string | null;
   repoGenerationJob: RepoGenerationJob | null;
+  onQuotaError: (message: string) => void;
   onClose: () => void;
   onResizeStart: (pane: "sidebar" | "agent", event: React.MouseEvent) => void;
 };
@@ -26,6 +27,7 @@ export function WorkspaceAgentSidebar({
   projectId,
   repoGenerationError,
   repoGenerationJob,
+  onQuotaError,
   onClose,
   onResizeStart,
 }: WorkspaceAgentSidebarProps) {
@@ -58,6 +60,7 @@ export function WorkspaceAgentSidebar({
         initialHistory={initialHistory}
         repoGenerationJob={repoGenerationJob}
         repoGenerationError={repoGenerationError}
+        onQuotaError={onQuotaError}
       />
     </aside>
   );

--- a/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
+++ b/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ComponentType } from "react";
+import { useRef, useState, type ComponentType } from "react";
 import Link from "next/link";
 import { ArrowLeft, FileText, LogIn, LogOut, PenTool, Settings } from "lucide-react";
 import {
@@ -13,6 +13,8 @@ import {
 import { getCreationQuota, type CreationQuota, type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import { getInitials } from "./helpers";
+
+const QUOTA_CACHE_TTL_MS = 15_000;
 
 type WorkspaceSidebarProps = {
   accountImage?: string | null;
@@ -50,20 +52,37 @@ export function WorkspaceSidebar({
   const [quota, setQuota] = useState<CreationQuota | null>(null);
   const [quotaError, setQuotaError] = useState<string | null>(null);
   const [quotaPending, setQuotaPending] = useState(false);
+  const quotaCacheRef = useRef<{ quota: CreationQuota; fetchedAt: number } | null>(null);
+  const quotaRequestRef = useRef<Promise<CreationQuota> | null>(null);
   const quotaRemainingPercent = quota?.limit
     ? Math.max(0, Math.min(100, (quota.remaining / quota.limit) * 100))
     : 0;
 
   async function handleMenuOpen(open: boolean) {
     if (!open) return;
+
+    const cached = quotaCacheRef.current;
+    if (cached && Date.now() - cached.fetchedAt < QUOTA_CACHE_TTL_MS) {
+      setQuotaError(null);
+      setQuota(cached.quota);
+      return;
+    }
+
+    if (quotaRequestRef.current) return;
+
     setQuotaPending(true);
     setQuotaError(null);
+    const request = getCreationQuota();
+    quotaRequestRef.current = request;
 
     try {
-      setQuota(await getCreationQuota());
+      const nextQuota = await request;
+      quotaCacheRef.current = { quota: nextQuota, fetchedAt: Date.now() };
+      setQuota(nextQuota);
     } catch (error) {
       setQuotaError(error instanceof Error ? error.message : "Could not load quota.");
     } finally {
+      if (quotaRequestRef.current === request) quotaRequestRef.current = null;
       setQuotaPending(false);
     }
   }

--- a/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
+++ b/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import { useState, type ComponentType } from "react";
 import Link from "next/link";
 import { ArrowLeft, FileText, LogIn, LogOut, PenTool, Settings } from "lucide-react";
 import {
@@ -6,9 +6,11 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { SavedProjectFile } from "@/lib/projects-client";
+import { getCreationQuota, type CreationQuota, type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import { getInitials } from "./helpers";
 
@@ -45,6 +47,27 @@ export function WorkspaceSidebar({
   onSignIn,
   onSignOut,
 }: WorkspaceSidebarProps) {
+  const [quota, setQuota] = useState<CreationQuota | null>(null);
+  const [quotaError, setQuotaError] = useState<string | null>(null);
+  const [quotaPending, setQuotaPending] = useState(false);
+  const quotaRemainingPercent = quota?.limit
+    ? Math.max(0, Math.min(100, (quota.remaining / quota.limit) * 100))
+    : 0;
+
+  async function handleMenuOpen(open: boolean) {
+    if (!open) return;
+    setQuotaPending(true);
+    setQuotaError(null);
+
+    try {
+      setQuota(await getCreationQuota());
+    } catch (error) {
+      setQuotaError(error instanceof Error ? error.message : "Could not load quota.");
+    } finally {
+      setQuotaPending(false);
+    }
+  }
+
   return (
     <aside
       className="group/sidebar relative hidden h-full shrink-0 flex-col border-r border-od-border-soft bg-od-surface lg:flex"
@@ -82,7 +105,7 @@ export function WorkspaceSidebar({
             {isSignedIn ? "Signed in" : "Guest session"}
           </p>
         </div>
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={(open) => void handleMenuOpen(open)}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
@@ -92,8 +115,41 @@ export function WorkspaceSidebar({
               <Settings className="h-4 w-4" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuContent align="end" className="w-64">
             <DropdownMenuGroup>
+              <DropdownMenuLabel className="flex flex-col gap-1.5 px-2 py-2">
+                <span className="block text-[12px] font-semibold text-od-ink">Beta quota</span>
+                <span aria-live="polite" className="block text-[11px] font-normal leading-4">
+                  {quotaPending ? (
+                    <span className="text-od-ink-faint">Loading…</span>
+                  ) : quotaError ? (
+                    <span className="text-red-600">{quotaError}</span>
+                  ) : quota ? (
+                    <span className="text-od-ink-muted">
+                      {quota.remaining} of {quota.limit} creation requests left
+                      {quota.actorType === "guest" ? ". Sign in to get 10." : "."}
+                    </span>
+                  ) : (
+                    <span className="text-od-ink-faint">Open settings to check usage.</span>
+                  )}
+                </span>
+                {quota ? (
+                  <div
+                    role="progressbar"
+                    aria-label={`${quota.remaining} of ${quota.limit} beta creation requests left`}
+                    aria-valuemin={0}
+                    aria-valuemax={quota.limit}
+                    aria-valuenow={quota.remaining}
+                    className="h-1.5 overflow-hidden rounded-full bg-od-canvas"
+                  >
+                    <div
+                      className="h-full rounded-full bg-od-ink"
+                      style={{ width: `${quotaRemainingPercent}%` }}
+                    />
+                  </div>
+                ) : null}
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
               {isSignedIn ? (
                 <DropdownMenuItem onSelect={onSignOut} className="cursor-pointer">
                   <LogOut className="h-4 w-4" />

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -112,6 +112,36 @@ export type RepoGenerationJob = {
   updatedAt: string;
 };
 
+export type CreationQuota = {
+  actorType: "guest" | "user";
+  limit: number;
+  used: number;
+  remaining: number;
+  resetAt: string | null;
+};
+
+export class CreationQuotaError extends Error {
+  quota?: CreationQuota;
+
+  constructor(message: string, quota?: CreationQuota) {
+    super(message);
+    this.name = "CreationQuotaError";
+    this.quota = quota;
+  }
+}
+
+function projectResponseError(data: unknown, fallback: string): Error {
+  const payload = data as
+    | { error?: string; code?: string; quota?: CreationQuota }
+    | null
+    | undefined;
+  const message = payload?.error ?? fallback;
+
+  return payload?.code === "creation_quota_exceeded"
+    ? new CreationQuotaError(message, payload.quota)
+    : new Error(message);
+}
+
 async function readProjectResponse(response: Response) {
   const contentType = response.headers.get("content-type");
 
@@ -230,6 +260,19 @@ export async function createProjectFile(
   return data.file;
 }
 
+export async function getCreationQuota(): Promise<CreationQuota> {
+  const response = await fetch(`${env.NEXT_PUBLIC_SERVER_URL}/api/usage/creation-quota`, {
+    credentials: "include",
+  });
+  const data = await readProjectResponse(response);
+
+  if (!response.ok) {
+    throw projectResponseError(data, "Could not load creation quota.");
+  }
+
+  return data.quota;
+}
+
 export async function updateProjectFile(
   projectId: string,
   fileId: string,
@@ -280,7 +323,7 @@ export async function startRepoGeneration(projectId: string): Promise<RepoGenera
   const data = await readProjectResponse(response);
 
   if (!response.ok) {
-    throw new Error(data?.error ?? "Could not start repository generation.");
+    throw projectResponseError(data, "Could not start repository generation.");
   }
 
   return data.job;
@@ -300,7 +343,7 @@ export async function streamRepoGeneration(
 
   if (!response.ok) {
     const data = await readProjectResponse(response);
-    throw new Error(data?.error ?? "Could not start repository generation.");
+    throw projectResponseError(data, "Could not start repository generation.");
   }
 
   let last = await consumeSSE<RepoGenerationJob>(response, onJob);
@@ -392,7 +435,7 @@ export async function chatWithProject(
   const data = await readProjectResponse(response);
 
   if (!response.ok) {
-    throw new Error(data?.error ?? "Could not ask project assistant.");
+    throw projectResponseError(data, "Could not ask project assistant.");
   }
 
   return data;

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+
+export const SITE_NAME = "OpenDiagram";
+export const SITE_URL = new URL("https://opendiagram.ink");
+export const GITHUB_URL = "https://github.com/Itz-Agasta/OpenDiagram";
+export const HOME_TITLE = "OpenDiagram — Open-Source AI Architecture Diagrams";
+export const HOME_DESCRIPTION =
+  "Create editable vibe diagrams for software architecture. Describe a system, shape it with AI, and keep diagrams, decisions, and project context connected.";
+
+export function createPrivateMetadata(title: string): Metadata {
+  return {
+    title,
+    robots: {
+      index: false,
+      follow: false,
+      nocache: true,
+      googleBot: {
+        index: false,
+        follow: false,
+        noimageindex: true,
+      },
+    },
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 
 import * as schema from "./schema";
 
-export { and, desc, eq, ne, or } from "drizzle-orm";
+export { and, desc, eq, ne, or, sql } from "drizzle-orm";
 
 export function createDb() {
   return drizzle(env.DATABASE_URL, { schema });

--- a/packages/db/src/migrations/0001_puzzling_arclight.sql
+++ b/packages/db/src/migrations/0001_puzzling_arclight.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "creation_usage" (
+	"id" text PRIMARY KEY NOT NULL,
+	"actor_type" text NOT NULL,
+	"actor_id" text NOT NULL,
+	"window_start" timestamp NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "creation_usage_actor_type_check" CHECK ("creation_usage"."actor_type" IN ('guest', 'user')),
+	CONSTRAINT "creation_usage_count_check" CHECK ("creation_usage"."count" >= 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "creation_usage_actor_window_idx" ON "creation_usage" USING btree ("actor_type","actor_id","window_start");

--- a/packages/db/src/migrations/meta/0001_snapshot.json
+++ b/packages/db/src/migrations/meta/0001_snapshot.json
@@ -1,0 +1,852 @@
+{
+  "id": "54df2a1e-3b31-48fb-8c95-6e6f4145296b",
+  "prevId": "ea34bac7-b6a0-4b69-ba75-76da229a7cb2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creation_usage": {
+      "name": "creation_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creation_usage_actor_window_idx": {
+          "name": "creation_usage_actor_window_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "creation_usage_actor_type_check": {
+          "name": "creation_usage_actor_type_check",
+          "value": "\"creation_usage\".\"actor_type\" IN ('guest', 'user')"
+        },
+        "creation_usage_count_check": {
+          "name": "creation_usage_count_check",
+          "value": "\"creation_usage\".\"count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_import_job": {
+      "name": "github_import_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_import_job_user_id_idx": {
+          "name": "github_import_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_import_job_status_idx": {
+          "name": "github_import_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_import_job_user_repo_partial_idx": {
+          "name": "github_import_job_user_repo_partial_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status NOT IN ('done', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_import_job_user_id_user_id_fk": {
+          "name": "github_import_job_user_id_user_id_fk",
+          "tableFrom": "github_import_job",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_import_job_project_id_project_id_fk": {
+          "name": "github_import_job_project_id_project_id_fk",
+          "tableFrom": "github_import_job",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cognee_dataset_id": {
+          "name": "cognee_dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cognee_status": {
+          "name": "cognee_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "cognee_error": {
+          "name": "cognee_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_status": {
+          "name": "generation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_userId_idx": {
+          "name": "project_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_user_id_user_id_fk": {
+          "name": "project_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file": {
+      "name": "project_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history": {
+          "name": "history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_projectId_idx": {
+          "name": "project_file_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_type_idx": {
+          "name": "project_file_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_project_id_fk": {
+          "name": "project_file_project_id_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_file_type_check": {
+          "name": "project_file_type_check",
+          "value": "\"project_file\".\"type\" IN ('diagram', 'doc')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783261294463,
       "tag": "0000_brainy_jasper_sitwell",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784618806312,
+      "tag": "0001_puzzling_arclight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/creation-usage.ts
+++ b/packages/db/src/schema/creation-usage.ts
@@ -1,0 +1,31 @@
+import { sql } from "drizzle-orm";
+import { check, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const creationUsageActorTypes = ["guest", "user"] as const;
+
+export const creationUsage = pgTable(
+  "creation_usage",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    actorType: text("actor_type", { enum: creationUsageActorTypes }).notNull(),
+    actorId: text("actor_id").notNull(),
+    windowStart: timestamp("window_start").notNull(),
+    count: integer("count").default(0).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("creation_usage_actor_window_idx").on(
+      table.actorType,
+      table.actorId,
+      table.windowStart,
+    ),
+    check("creation_usage_actor_type_check", sql`${table.actorType} IN ('guest', 'user')`),
+    check("creation_usage_count_check", sql`${table.count} >= 0`),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth";
+export * from "./creation-usage";
 export * from "./github-import-job";
 export * from "./project";
 export * from "./project-file";


### PR DESCRIPTION
## Summary

This PR adds two production foundations to OpenDiagram:

1. Technical SEO metadata and crawler controls for the public web application.
2. A database-backed beta creation quota to control hosted AI usage.

The work is based on the latest upstream `main` branch and preserves the recent diagram harness and malformed tool-call repair changes.

## Technical SEO

### Public homepage

- Adds a canonical production URL for `https://opendiagram.ink`.
- Adds descriptive page titles and metadata.
- Adds Open Graph and Twitter preview metadata.
- Adds Organization, WebSite, and SoftwareApplication JSON-LD.
- Sanitizes serialized JSON-LD before rendering.
- Adds `robots.txt`.
- Adds a generated sitemap containing the currently available public route.
- Uses the original OpenDiagram repository as the canonical source.

### Private application routes

The following application routes now emit `noindex`, `nofollow`, and `nocache` metadata:

- `/dashboard`
- `/login`
- `/import/*`
- `/project/*`

This keeps authenticated workspaces and user-specific pages out of search results.

## Beta creation quota

The hosted beta now has persistent creation limits:

| User type | Allocation |
| --- | ---: |
| Guest | 3 requests |
| Signed-in user | 10 requests |

This is a fixed beta allocation rather than a rolling per-minute rate limit. The API currently reports `resetAt: null`.

### Enforcement

Quota is consumed for operations that use hosted AI capacity:

- Diagram-agent requests
- Project assistant requests
- Initial repository generation
- Retrying repository generation after a failed generation

Ordinary project and file CRUD operations do not consume quota.

Invalid diagram payloads are rejected before quota is consumed.

### Guest and account identity

- Guests are identified by an HTTP-only cookie.
- Signed-in users are identified by their authenticated user ID.
- Signing in gives a guest access to the signed-in allocation.

### API behavior

Quota responses include:

- `X-CreationQuota-Limit`
- `X-CreationQuota-Used`
- `X-CreationQuota-Remaining`

These headers are exposed through CORS.

When the allocation is exhausted, the API returns HTTP `429` with:

```json
{
  "error": "Human-readable quota message",
  "code": "creation_quota_exceeded",
  "quota": {
    "actorType": "guest",
    "limit": 3,
    "used": 3,
    "remaining": 0,
    "resetAt": null
  }
}

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds technical SEO for the public site and a persistent beta creation quota to control hosted usage. Improves search visibility and gives clear quota feedback in the UI and API.

- New Features
  - Technical SEO
    - Canonical https://opendiagram.ink, titles/descriptions, Open Graph/Twitter, and Organization/WebSite/SoftwareApplication JSON‑LD (sanitized).
    - robots.txt (disallows /api) and a generated sitemap.
    - Private routes (/dashboard, /login, /import/*, /project/*) emit noindex/nofollow/nocache.
  - Beta creation quota
    - Limits and identity: guests 3, users 10; guests tracked via HTTP‑only cookie; sign in to upgrade allocation.
    - Enforcement: diagram agent, project assistant, repository generation (initial and retries for GitHub imports); CRUD ignored; invalid payloads rejected before consuming quota.
    - API: X‑CreationQuota-* headers (CORS‑exposed); 429 with code "creation_quota_exceeded" and a quota snapshot; GET /api/usage/creation-quota returns current usage (non-cacheable).
    - UI: quota bar in the workspace settings dropdown and a modal when the limit is reached.

- Migration
  - Run database migrations to create the creation_usage table.

<sup>Written for commit 126780202211814a5fe66ff2ec84f15a0156420f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

