### PR TITLE
fix(web): import harness diagram-schema via subpath to fix client build

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  transpilePackages: ["@OpenDiagram/harness"],
   images: {
     remotePatterns: [
       {

--- a/apps/web/src/components/whiteboard/ai-chat-panel/types.ts
+++ b/apps/web/src/components/whiteboard/ai-chat-panel/types.ts
@@ -1,6 +1,6 @@
 import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
 import type { DiagramSpec, RenderSkeleton } from "@OpenDiagram/harness";
-import { diagramTypeSchema } from "@OpenDiagram/harness";
+import { diagramTypeSchema } from "@OpenDiagram/harness/diagram-schema";
 import type { StoredChatMessage } from "@/lib/chat-history";
 import type { RepoGenerationJob } from "@/lib/projects-client";
 

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "elkjs": "^0.11.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./diagram-schema": "./src/diagram-schema.ts"
   },
   "scripts": {
     "test": "bun test"


### PR DESCRIPTION
The AI chat panel is a client component that value-imports diagramTypeSchema from the harness. Going through the barrel (@OpenDiagram/harness) pulled the entire server-side diagram engine (elkjs layout, renderer) into the browser bundle, and Turbopack could not resolve the harness .js import specifiers against its .ts source, breaking the workspace canvas build.

- Add a ./diagram-schema subpath export to the harness (self-contained, zod-only) so clients can import just the schema, not the engine.
- Point the client value-import at the subpath.
- Add transpilePackages for the harness so Turbopack compiles its TS source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the client build by importing the diagram schema from a subpath instead of the barrel. This keeps the server-side engine out of the browser bundle and allows Turbopack to compile the harness TS.

- **Bug Fixes**
  - Added `./diagram-schema` subpath export in `@OpenDiagram/harness` (schema-only).
  - Updated import to `@OpenDiagram/harness/diagram-schema` in the AI chat panel.
  - Declared `zod` in `@OpenDiagram/harness` so the subpath is self-contained without hoisting.

<sup>Written for commit bfc0a70a2f311be635c97ec69c9216255027642d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

