### PR TITLE
fix: remove duplicate Picasso label

### DIFF
--- a/apps/web/src/components/whiteboard/ai-chat-panel/AIChatComposer.tsx
+++ b/apps/web/src/components/whiteboard/ai-chat-panel/AIChatComposer.tsx
@@ -66,7 +66,6 @@ export function AIChatComposer({
     }
     return [...groups.entries()];
   }, [providerOptions]);
-  const providerLabel = selectedProvider?.providerLabel ?? "Picasso";
   const statusColor = providerUsage
     ? "bg-od-green"
     : status === "submitted" || status === "streaming"
@@ -155,7 +154,6 @@ export function AIChatComposer({
               className="flex min-w-0 flex-1 items-center justify-end gap-1.5 pr-2 text-right text-xs text-od-ink-faint"
             >
               <span aria-hidden className={`size-1.5 shrink-0 rounded-full ${statusColor}`} />
-              <span className="truncate">{providerLabel}</span>
             </p>
             <PromptInputSubmit status={status} onStop={onStop} />
           </PromptInputFooter>


### PR DESCRIPTION
## Summary
- remove duplicate Picasso provider label beside the submit button
- preserve selected-model label and provider status indicator

## Validation
- bun run check
- bun run check-types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the extra "Picasso" provider label next to the submit button in `AIChatComposer` to avoid duplication. The selected model label and the provider status dot remain unchanged.

<sup>Written for commit d20de3f8cf21f551615521da63301e71c1f772bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

