### PR TITLE
fix(observability): correct Sentry environment tagging and add Gemini AI tracing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,12 +22,21 @@ DATABASE_DIRECT_URL=postgresql://postgres:postgres@126.0.1.1:54322/postgres
 # Web
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
-# Sentry - OPTIONAL, build-time only (error tracking + tracing).
-# DSNs are hardcoded in the Sentry config files (public values). This token is
-# the only secret. Generate at:
+# Sentry - both variables below are OPTIONAL. Leave them unset and the app still
+# builds, boots, and reports normally. DSNs stay hardcoded in the Sentry config
+# files (public values), so they are deliberately not env vars.
+
+# Source-map upload token. The only Sentry secret; build-time only. Generate at:
 # https://opendiagram.sentry.io/settings/auth-tokens/ (needs project:releases).
 # Set it in apps/web/.env - `next build` loads env from the app dir, so that is
 # where next.config.ts reads it. Leave unset and builds still work; prod stack
 # traces just stay minified. Listed here for discoverability only; it is not
 # consumed from the repo root.
 SENTRY_AUTH_TOKEN=
+
+# Fraction of traces sampled, 0..1. Both default to 1 (capture everything).
+# Turn them down if span volume ever becomes a problem - but note that agent
+# runs are sampled as a whole span tree, so a dropped root span loses the entire
+# run, tool calls and token counts included.
+SENTRY_TRACES_SAMPLE_RATE=
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,6 +18,7 @@
     "@ai-sdk/google": "^4.0.5",
     "@ai-sdk/groq": "^4.0.5",
     "@ai-sdk/openai": "^4.0.5",
+    "@ai-sdk/otel": "^1.0.37",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@sentry/bun": "10.68.0",
     "@sentry/hono": "10.68.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,8 @@ import { evlog, type EvlogVariables } from "evlog/hono";
 import { createSentryDrain } from "evlog/sentry";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+// Registers the AI SDK's OpenTelemetry integration; must load before any AI call.
+import "./lib/telemetry";
 import { aiSettingsRoute } from "./routes/ai-settings";
 import { diagramRoute } from "./routes/diagram";
 import { githubImportRoute, githubRoute } from "./routes/github";
@@ -39,7 +41,22 @@ const app = new Hono<EvlogVariables>();
 app.use(
   sentry(app, {
     dsn: SENTRY_DSN,
-    tracesSampleRate: env.NODE_ENV === "development" ? 1.0 : 0.1,
+    // Without this the SDK falls back to "production", so local dev traffic
+    // lands in the same bucket as Cloud Run and every env filter is useless.
+    // Release is picked up automatically from SENTRY_RELEASE when deploys set it.
+    environment: env.NODE_ENV,
+    tracesSampleRate: env.SENTRY_TRACES_SAMPLE_RATE,
+    // Send spans as they finish instead of buffering until the root span ends.
+    // /api/diagram/chat is a long-lived SSE response, so in transaction mode its
+    // spans are lost whenever the process restarts mid-stream.
+    traceLifecycle: "stream",
+    // Keep the model/token/latency metadata, drop the content — user prompts
+    // and repo context must not leave the server.
+    dataCollection: { genAI: { inputs: false, outputs: false } },
+    // VercelAI is inert on Bun (see lib/telemetry.ts); @ai-sdk/otel emits the
+    // gen_ai spans instead. Drop it so the two never produce duplicate spans
+    // if Sentry later adds Bun support for the diagnostics channel.
+    integrations: (defaults) => defaults.filter((i) => i.name !== "VercelAI"),
   }),
 );
 
@@ -51,13 +68,17 @@ app.use(
 // log drain is supplementary, so a dropped log on a Cloud Run freeze never loses
 // the error itself. Rejections are swallowed to avoid unhandled rejections.
 const fsDrain = createFsDrain();
-const sentryDrain = createSentryDrain({ dsn: SENTRY_DSN });
+const sentryDrain = createSentryDrain({ dsn: SENTRY_DSN, environment: env.NODE_ENV });
 app.use(
   evlog({
     drain: (ctx) => {
       fsDrain(ctx);
       if (ctx.event.level === "warn" || ctx.event.level === "error") {
-        void Promise.resolve(sentryDrain(ctx)).catch(() => {});
+        // Defer into the chain so a synchronous throw is caught too, rather
+        // than escaping as an uncaught error.
+        void Promise.resolve()
+          .then(() => sentryDrain(ctx))
+          .catch(() => {});
       }
     },
   }),

--- a/apps/server/src/lib/repo-ai.ts
+++ b/apps/server/src/lib/repo-ai.ts
@@ -3,6 +3,7 @@ import { diagramSpecSchema, type DiagramSpec, type DiagramType } from "@OpenDiag
 import { env } from "@OpenDiagram/env/server";
 import { generateObject, generateText } from "ai";
 import { buildIconCatalog } from "./icons/registry";
+import { aiTelemetry } from "./telemetry";
 
 // The AI SDK retries retryable errors (429/5xx) with exponential backoff up to
 // this many times. A single provider (Gemini) handles every task — no
@@ -121,6 +122,7 @@ export async function generateDiagramSpec(input: {
     schema: diagramSpecSchema,
     system: buildSystemPrompt(input.diagramType),
     prompt: userPrompt,
+    telemetry: aiTelemetry("repo-diagram-spec"),
     maxRetries: LLM_MAX_RETRIES,
     // Bounds runaway/repetition-loop generations (observed during testing:
     // gemini-2.5-flash occasionally gets stuck dumping a huge repeated string
@@ -146,6 +148,7 @@ export async function generateGroundedProjectAnswer(input: {
       "Keep answers concise, specific, and grounded in the project's diagrams, docs, and files.",
     ].join("\n"),
     prompt: `Project context:\n${input.context}\n\nUser question:\n${input.message}`,
+    telemetry: aiTelemetry("project-chat"),
     maxRetries: LLM_MAX_RETRIES,
     maxOutputTokens: 1200,
   });
@@ -186,6 +189,7 @@ export async function generateArchitectureDoc(input: {
       `Write the document "${input.title}" based on the goal and context above.`,
       "Return valid markdown only — no wrapper explanations.",
     ].join("\n"),
+    telemetry: aiTelemetry("architecture-doc"),
     maxRetries: LLM_MAX_RETRIES,
     maxOutputTokens: 4096,
   });

--- a/apps/server/src/lib/telemetry.ts
+++ b/apps/server/src/lib/telemetry.ts
@@ -1,0 +1,22 @@
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { registerTelemetry } from "ai";
+
+// Sentry's vercelAIIntegration instruments AI SDK v7 through the Node.js
+// diagnostics tracing channel, which Bun does not implement — verified against
+// a live Gemini call that produced zero gen_ai spans. The AI SDK's own
+// OpenTelemetry integration does not need that channel: it emits GenAI SemConv
+// spans through the @opentelemetry/api singleton, and @sentry/bun registers a
+// SentryTracerProvider there, so the spans land in Sentry's AI Agents views.
+// The Sentry integration is disabled in index.ts so the two can't double up.
+registerTelemetry(new OpenTelemetry());
+
+/**
+ * Per-call telemetry settings for AI SDK calls.
+ *
+ * Metadata only: model, token counts, latency, and tool names reach Sentry;
+ * prompts and completions never leave the server. The AI SDK records both by
+ * default, so the opt-out has to be explicit on every call.
+ */
+export function aiTelemetry(functionId: string) {
+  return { functionId, recordInputs: false, recordOutputs: false };
+}

--- a/apps/server/src/routes/ai-settings.ts
+++ b/apps/server/src/routes/ai-settings.ts
@@ -4,6 +4,7 @@ import { userAiProvider, userAiProviderKinds } from "@OpenDiagram/db/schema/user
 import { generateText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
+import { aiTelemetry } from "../lib/telemetry";
 import {
   ByokEncryptionError,
   canEncryptByokKeys,
@@ -51,6 +52,7 @@ async function assertKeyWorks(provider: string, apiKey: string, modelId: string)
   await generateText({
     model: def.createModel(apiKey, modelId),
     prompt: "Reply with the single character: ok",
+    telemetry: aiTelemetry("byok-key-check"),
     maxOutputTokens: 8,
     maxRetries: 0,
   });

--- a/apps/server/src/routes/diagram.ts
+++ b/apps/server/src/routes/diagram.ts
@@ -23,6 +23,7 @@ import {
 } from "../lib/creation-quota";
 import { resolveModel } from "../lib/ai-provider/resolve";
 import { LLM_MAX_RETRIES } from "../lib/repo-ai";
+import { aiTelemetry } from "../lib/telemetry";
 
 const chatRequestSchema = z.object({
   // UIMessage shape is owned by the AI SDK and too deep to mirror — validated
@@ -127,6 +128,7 @@ diagramRoute.post("/chat", async (c) => {
     instructions: buildSystemPrompt(currentSpec),
     messages: modelMessages,
     tools,
+    telemetry: aiTelemetry("diagram-chat"),
     stopWhen: isStepCount(6),
     experimental_repairToolCall: async ({ toolCall, error }) => {
       if (NoSuchToolError.isInstance(error) || toolCall.toolName !== "draw_diagram") return null;

--- a/apps/server/src/routes/orchestrate.ts
+++ b/apps/server/src/routes/orchestrate.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
 import { env } from "@OpenDiagram/env/server";
+import { aiTelemetry } from "../lib/telemetry";
 
 const requestSchema = z.object({
   text: z.string().trim().min(1).max(2000),
@@ -45,6 +46,7 @@ orchestrateRoute.post("/", async (c) => {
       model: groq("groq/compound-mini"),
       system: SYSTEM_PROMPT,
       prompt: text,
+      telemetry: aiTelemetry("orchestrate-intent"),
       timeout: 15_000,
     });
 

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,10 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN } from "./sentry.dsn";
+import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
-  // Errors + tracing only (no session replay). Full sampling in dev, 10% in prod.
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  // Errors + tracing only (no session replay).
+  tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });
 
 // Instrument client-side router navigations for tracing.

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,8 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
+import {
+  WEB_SENTRY_DSN,
+  WEB_SENTRY_ENVIRONMENT,
+  WEB_SENTRY_TRACES_SAMPLE_RATE,
+} from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
+  environment: WEB_SENTRY_ENVIRONMENT,
   // Errors + tracing only (no session replay).
   tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/sentry.dsn.ts
+++ b/apps/web/sentry.dsn.ts
@@ -8,3 +8,12 @@ export const WEB_SENTRY_DSN =
 
 // Tunable without a code change; defaults to 1 when the env var is unset.
 export const WEB_SENTRY_TRACES_SAMPLE_RATE = env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;
+
+// Left to itself the Next.js SDK reports Vercel deploys as "vercel-production",
+// while the Cloud Run server reports "production" — the same deploy would sit
+// under two different environment names and no single filter would match both.
+// NEXT_PUBLIC_VERCEL_ENV is set by Vercel at build and runtime ("production" |
+// "preview" | "development") and, being NEXT_PUBLIC_, is inlined into the
+// browser bundle too, so client and server agree. Falls back to NODE_ENV
+// locally, where Vercel's variables are absent.
+export const WEB_SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV;

--- a/apps/web/sentry.dsn.ts
+++ b/apps/web/sentry.dsn.ts
@@ -1,5 +1,10 @@
+import { env } from "@OpenDiagram/env/web";
+
 // Public Sentry DSN for the web project. It ships in the client bundle, so it is
 // not a secret. Single source of truth: the three Sentry runtime configs and the
 // evlog drain all import from here, so rotating the DSN is a one-line change.
 export const WEB_SENTRY_DSN =
   "https://211bc816992431e815a19fcf8775f16c@o4511790063812608.ingest.us.sentry.io/4511790124826624";
+
+// Tunable without a code change; defaults to 1 when the env var is unset.
+export const WEB_SENTRY_TRACES_SAMPLE_RATE = env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -3,5 +3,8 @@ import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
+  // The client and server SDKs fall back to NODE_ENV on their own; the edge one
+  // only reads SENTRY_ENVIRONMENT, so without this it defaults to "production".
+  environment: process.env.NODE_ENV,
   tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN } from "./sentry.dsn";
+import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,10 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
+import {
+  WEB_SENTRY_DSN,
+  WEB_SENTRY_ENVIRONMENT,
+  WEB_SENTRY_TRACES_SAMPLE_RATE,
+} from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
-  // The client and server SDKs fall back to NODE_ENV on their own; the edge one
-  // only reads SENTRY_ENVIRONMENT, so without this it defaults to "production".
-  environment: process.env.NODE_ENV,
+  environment: WEB_SENTRY_ENVIRONMENT,
   tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,7 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
+import {
+  WEB_SENTRY_DSN,
+  WEB_SENTRY_ENVIRONMENT,
+  WEB_SENTRY_TRACES_SAMPLE_RATE,
+} from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
+  environment: WEB_SENTRY_ENVIRONMENT,
   tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
-import { WEB_SENTRY_DSN } from "./sentry.dsn";
+import { WEB_SENTRY_DSN, WEB_SENTRY_TRACES_SAMPLE_RATE } from "./sentry.dsn";
 
 Sentry.init({
   dsn: WEB_SENTRY_DSN,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  tracesSampleRate: WEB_SENTRY_TRACES_SAMPLE_RATE,
 });

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import NextError from "next/error";
+import { useEffect } from "react";
+
+// The App Router's last-resort error boundary. Without it, React render errors
+// in the root layout and client components never reach Sentry.
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        {/* NextError is Next.js's own error page. Its types want a statusCode,
+            but the App Router does not expose one for render errors, so 0
+            renders the generic message. */}
+        <NextError statusCode={0} />
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -6,7 +6,13 @@ import { useEffect } from "react";
 
 // The App Router's last-resort error boundary. Without it, React render errors
 // in the root layout and client components never reach Sentry.
-export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+export default function GlobalError({
+  error,
+  retry,
+}: {
+  error: Error & { digest?: string };
+  retry: () => void;
+}) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -18,6 +24,13 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
             but the App Router does not expose one for render errors, so 0
             renders the generic message. */}
         <NextError statusCode={0} />
+        {/* global-error replaces the root layout, so globals.css never loads
+            here — these styles have to be inline. */}
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <button type="button" onClick={() => retry()} style={{ cursor: "pointer" }}>
+            Try again
+          </button>
+        </div>
       </body>
     </html>
   );

--- a/apps/web/src/lib/evlog.ts
+++ b/apps/web/src/lib/evlog.ts
@@ -1,7 +1,7 @@
 import { createEvlog } from "evlog/next";
 import { createInstrumentation } from "evlog/next/instrumentation/create";
 import { createSentryDrain } from "evlog/sentry";
-import { WEB_SENTRY_DSN } from "../../sentry.dsn";
+import { WEB_SENTRY_DSN, WEB_SENTRY_ENVIRONMENT } from "../../sentry.dsn";
 
 // The web app runs on serverless (Vercel) with an ephemeral, read-only FS, so
 // there is no local FS drain here (unlike the Bun server). evlog still emits
@@ -11,7 +11,7 @@ import { WEB_SENTRY_DSN } from "../../sentry.dsn";
 // stream.
 const sentryDrain = createSentryDrain({
   dsn: WEB_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  environment: WEB_SENTRY_ENVIRONMENT,
 });
 
 export const { withEvlog, useLogger, log, createError } = createEvlog({

--- a/apps/web/src/lib/evlog.ts
+++ b/apps/web/src/lib/evlog.ts
@@ -9,7 +9,10 @@ import { WEB_SENTRY_DSN } from "../../sentry.dsn";
 // warn/error wide events are forwarded to Sentry Logs — this keeps us inside the
 // free Logs allotment while routine info/debug logs stay in the platform's log
 // stream.
-const sentryDrain = createSentryDrain({ dsn: WEB_SENTRY_DSN });
+const sentryDrain = createSentryDrain({
+  dsn: WEB_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+});
 
 export const { withEvlog, useLogger, log, createError } = createEvlog({
   service: "OpenDiagram-web",

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "@ai-sdk/google": "^4.0.5",
         "@ai-sdk/groq": "^4.0.5",
         "@ai-sdk/openai": "^4.0.5",
+        "@ai-sdk/otel": "^1.0.37",
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@sentry/bun": "10.68.0",
         "@sentry/hono": "10.68.0",
@@ -261,6 +262,8 @@
     "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jC2r+StEuk8uIldfP4j8nBwOEBJ2TRwy/bz71SHMZ3NG6PSbvRPXGfyoHHR6JTm1O5GcIww0f6B8LznzkrseDA=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@4.0.20", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/Hu+btLIO2zuYqCp//vBBAGdM/BeN4gds+NWrlv7Y9WrcTXwnEEwh6P3QZIWh2Tt1I1lswuDIpAJ4t/c/rws3Q=="],
+
+    "@ai-sdk/otel": ["@ai-sdk/otel@1.0.37", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@opentelemetry/api": "1.9.1", "ai": "7.0.37" } }, "sha512-qaXUeOTZfbugaYKcqgqho79YOdvLWFlBQt984n5fOozChfgkybJJHotkqsKy3aJGU5GcgJuMM+oamb9JtPQnwA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.14", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA=="],
 
@@ -2718,6 +2721,10 @@
 
     "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA=="],
 
+    "@ai-sdk/otel/@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
+
+    "@ai-sdk/otel/ai": ["ai@7.0.37", "", { "dependencies": { "@ai-sdk/gateway": "4.0.28", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw=="],
+
     "@apm-js-collab/code-transformer/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
@@ -2931,6 +2938,10 @@
     "web/ai": ["ai@7.0.37", "", { "dependencies": { "@ai-sdk/gateway": "4.0.28", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "@ai-sdk/otel/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.28", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q=="],
+
+    "@ai-sdk/otel/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA=="],
 
     "@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -29,6 +29,10 @@ export const env = createEnv({
     BYOK_ENCRYPTION_KEY: z.string().min(1).optional(),
     COGNEE_BASE_URL: z.url().optional(),
     COGNEE_API_KEY: z.string().min(1).optional(),
+    // Fraction of traces sampled, 0..1. Full sampling by default: gen_ai runs
+    // are sampled as a whole span tree, so dropping a root span loses the
+    // entire agent run. Lower it here if span volume becomes a problem.
+    SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(1),
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   },
   runtimeEnv: process.env,

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -4,9 +4,13 @@ import { z } from "zod";
 export const env = createEnv({
   client: {
     NEXT_PUBLIC_SERVER_URL: z.url(),
+    // Fraction of traces sampled, 0..1. Full sampling by default. The DSN stays
+    // hardcoded in apps/web/sentry.dsn.ts.
+    NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(1),
   },
   runtimeEnv: {
     NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
+    NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   emptyStringAsUndefined: true,


### PR DESCRIPTION
 - Server sent no environment, so the SDK defaulted to production and local dev traffic was indistinguishable from Cloud Run. Every env filter and env-scoped alert was silently useless.
 - apps/web had no global-error.tsx, so React render errors never reached Sentry. The web project had not recorded a single error since setup.
 - The evlog Sentry drain invoked before the promise wrap, letting a synchronous throw escape as an uncaught error.

AI tracing
Sentry's vercelAIIntegration relies on the Node.js diagnostics tracing channel, which Bun does not implement - a live Gemini call produced zero gen_ai spans. Registering the AI SDK's own OpenTelemetry integration works instead, since @sentry/bun installs a global SentryTracerProvider. Verified end to end: invoke_agent/chat spans with per-model latency and token counts. Metadata only; prompts and completions are explicitly opted out and their absence was verified.

 Config
Trace sample rate moved to optional env vars defaulting to 1. traceLifecycle: "stream" added so the /api/diagram/chat SSE route is traced at all. DSNs stay hardcoded by design.

 Adds one dependency: @ai-sdk/otel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry environment tagging across server, web, and edge (aligned between Vercel and Cloud Run), and enables AI tracing on Bun so Gemini runs show up in Sentry with token and latency data. Adds a global web error boundary with retry and makes trace sampling configurable; SSE chat streams are now traced.

- **New Features**
  - Capture GenAI spans on Bun via AI SDK OpenTelemetry (`@ai-sdk/otel`); Sentry’s VercelAI integration is disabled to avoid duplicates.
  - Per-call telemetry sends metadata only (model, tokens, latency); prompts and completions are not recorded.
  - Trace sampling is env-driven (`SENTRY_TRACES_SAMPLE_RATE`, `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE`, default 1). `/api/diagram/chat` uses `traceLifecycle: "stream"` for long SSE streams.
  - Web: add `global-error.tsx` to send React render errors to Sentry and show a Retry button.

- **Bug Fixes**
  - Set and normalize Sentry `environment` across server, web, edge, and evlog drains; web uses `NEXT_PUBLIC_VERCEL_ENV` so Vercel and Cloud Run both report `production`/`preview`/`development` (avoids `vercel-production` split).
  - Defer the evlog Sentry drain into the promise chain to catch sync throws.

<sup>Written for commit d5e00513fa1bfbb2c020f140046154d827dbfe3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

