### PR TITLE
chore(ci): add code quality workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  # Actions used by workflows in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Base image for the Hono API container
+  - package-ecosystem: "docker"
+    directory: "/apps/server"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Bun deps are intentionally NOT managed yet.
+  #
+  # This repo declares shared versions in `workspaces.catalog` and every
+  # workspace package references them with `catalog:`. Dependabot's bun parser
+  # skips `catalog:` specifiers, so it would see almost nothing here, and it has
+  # an open bug where it strips the catalog block from bun.lock.
+  #   fix:  https://github.com/dependabot/dependabot-core/pull/14418  (open)
+  #   bug:  https://github.com/dependabot/dependabot-core/issues/12522 (open)
+  # Uncomment once both are resolved.
+  #
+  # - package-ecosystem: "bun"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   open-pull-requests-limit: 5
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #     include: "scope"
+  #   groups:
+  #     bun-minor-patch:
+  #       patterns: ["*"]
+  #       update-types: ["minor", "patch"]

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -38,3 +38,23 @@ jobs:
 
       - name: Harness tests
         run: just test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Env schemas are validated at runtime on the real deploys, so the build
+      # only needs to prove that everything bundles.
+      - name: Build
+        run: bun run build
+        env:
+          SKIP_ENV_VALIDATION: "1"

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,0 +1,40 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Lint, types, tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Bun version comes from `packageManager` in the root package.json
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup just
+        uses: extractions/setup-just@v4
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint and format check
+        run: just check-ci
+
+      - name: Typecheck
+        run: just types
+
+      - name: Harness tests
+        run: just test

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -16,16 +16,17 @@ jobs:
   quality:
     name: Lint, types, tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Bun version comes from `packageManager` in the root package.json
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Setup just
-        uses: extractions/setup-just@v4
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -42,19 +43,22 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Env schemas are validated at runtime on the real deploys, so the build
-      # only needs to prove that everything bundles.
+      # Placeholder value: the build only has to prove everything bundles, but
+      # NEXT_PUBLIC_SERVER_URL is read at build time by src/lib/auth-client.ts,
+      # which throws without it. Turbo passes NEXT_PUBLIC_* through to the task
+      # automatically via framework inference.
       - name: Build
         run: bun run build
         env:
-          SKIP_ENV_VALIDATION: "1"
+          NEXT_PUBLIC_SERVER_URL: "http://localhost:3000"

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-    "workspaceId": "bc7e2422-3367-414c-a029-435f38f54b00",
-    "defaultEnvironment": "dev",
-    "gitBranchToEnvironmentMapping": null
+  "workspaceId": "bc7e2422-3367-414c-a029-435f38f54b00",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/Justfile
+++ b/Justfile
@@ -44,11 +44,11 @@ reinstall: clean
 setup: reinstall
     bun run build
 
-# Lint and format (oxlint + oxfmt)
+# Lint and format (oxlint --deny-warnings + oxfmt --write)
 check:
     bun run check
 
-# Lint and format check without writing (CI)
+# Same lint bar as `check`, but reports instead of writing (CI)
 check-ci:
     bunx oxlint --deny-warnings --format github
     bunx oxfmt --check

--- a/Justfile
+++ b/Justfile
@@ -48,9 +48,18 @@ setup: reinstall
 check:
     bun run check
 
+# Lint and format check without writing (CI)
+check-ci:
+    bunx oxlint --deny-warnings --format github
+    bunx oxfmt --check
+
 # Typecheck all packages with tsgo
 types:
     bun run check-types
+
+# Harness geometry tests
+test:
+    cd packages/harness && bun test
 
 # Start web dev server
 web:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "docker:up": "docker compose up -d --build",
     "docker:down": "docker compose down",
     "docker:logs": "docker compose logs -f",
-    "check": "oxlint && oxfmt --write"
+    "check": "oxlint --deny-warnings && oxfmt --write"
   },
   "dependencies": {
     "@OpenDiagram/env": "workspace:*",


### PR DESCRIPTION
Adds CI and dependency automation to the repo.

**`.github/workflows/codequality.yml`** - runs on pushes to `main` and all PRs:

- `just check-ci` - oxlint (`--deny-warnings`, GitHub annotations) + `oxfmt --check`
- `just types` - tsgo `--noEmit` across all 8 workspace packages via turbo
- `just test` - the harness geometry suite (24 tests), per AGENTS.md

Concurrency group cancels superseded runs, `permissions: contents: read`.
Bun version is inferred from `packageManager` in the root `package.json`, so
there's no version to keep in sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Code Quality CI workflow and Dependabot config to automate linting, type checks, tests, builds, and dependency updates. This keeps PRs green and reduces manual maintenance.

- **New Features**
  - Code Quality workflow on pushes to `main` and all PRs.
  - Runs `just check-ci` (`oxlint --deny-warnings`, `oxfmt --check`), `just types` (`tsgo --noEmit`), `just test`; adds a parallel Build job (`bun run build`) with a placeholder `NEXT_PUBLIC_SERVER_URL` to catch bundling and build-time issues early.
  - Cancels superseded runs; `permissions: contents: read`. Actions pinned to commit SHAs and job `timeout-minutes` set. `bun` version inferred from root `package.json`.
  - Add `check-ci` and `test` tasks to `Justfile`; make `check` deny warnings; document that `check` and `check-ci` share the same lint bar; reformat `.infisical.json`.

- **Dependencies**
  - Add `.github/dependabot.yml` for `github-actions` and `docker` updates (weekly, Monday).
  - Leave `bun` updates commented out due to `workspaces.catalog` usage and current Dependabot limitations; enable when fixed.

<sup>Written for commit cd0eabf575cd3c7f87c90d1be4b5c9d8c8c3643e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

