### PR TITLE
fix marketing video r2 links

### DIFF
--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -49,7 +49,7 @@ const showcaseItems = [
       "Model tables, keys, and cardinality as first-class objects—not a one-shot image export. Generate an entity-relationship diagram from a schema description or product brief, then adjust fields, rename entities, and rewire associations when the data model shifts. OpenDiagram is built for ERD work you will open again next sprint, not archive in a slide deck.",
     media: {
       kind: "video" as const,
-      src: assetUrl("/videos/od-erd-tutorial.mp4"),
+      src: assetUrl("/marketing/features/erd-tutorial.mp4"),
       alt: "Tutorial video: generating and editing an entity-relationship diagram (ERD) in OpenDiagram",
     },
   },
@@ -61,7 +61,7 @@ const showcaseItems = [
       "Map onboarding paths, approval chains, incident runbooks, and API request lifecycles as flowcharts you can actually revise. Branch logic, labels, and steps stay on the canvas so product and engineering can debate the path without redrawing from a blank page. Use natural language to draft the flow, then pin the sequence that matches how the system really behaves.",
     media: {
       kind: "video" as const,
-      src: assetUrl("/videos/od-flow-tutorial.mp4"),
+      src: assetUrl("/marketing/features/flow-tutorial.mp4"),
       alt: "Tutorial video: creating and refining a process flowchart in OpenDiagram",
     },
   },


### PR DESCRIPTION
## What does this PR do?

fixes broken links for feature videos in feature page

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Diagram engine / layout change (`packages/harness`)
- [ ] Documentation
- [ ] Chore / refactor / CI

2 word fix


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken feature tutorial videos on the Features page by pointing to the correct R2 marketing paths. Videos now load correctly in production (/marketing/features/erd-tutorial.mp4 and /marketing/features/flow-tutorial.mp4).

<sup>Written for commit 79dc54d86023354d68195b35996ab9a5a99d1c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

