### PR TITLE
fix(billing): make a lost Dodo webhook visible, and survivable

### DIFF
--- a/apps/server/src/lib/ai-grant.ts
+++ b/apps/server/src/lib/ai-grant.ts
@@ -12,13 +12,11 @@
  * Streaming routes (`routes/diagram.ts`) call `enforceAiQuota` directly, because
  * they settle from `onFinish`/`onError` callbacks rather than around an await.
  */
+import type { AuditableLogger } from "evlog";
 import type { Context } from "hono";
-import { createLogger } from "evlog";
 import { resolveModel } from "./ai-provider/resolve";
 import { enforceAiQuota, quotaErrorResponse } from "./quota";
 import type { AiCallOptions, AiUsage } from "./repo-ai";
-
-const log = createLogger({ module: "ai-grant" });
 
 export type AiGrant = {
   /** Pass to a repo-ai helper so it runs on the resolved model, not the platform default. */
@@ -42,12 +40,13 @@ export type AiGrant = {
  * `meter: false` resolves a model but takes no credit — for work already paid for
  * on a previous request, such as resuming an in-flight repo generation.
  */
-export async function takeAiGrant(
-  c: Context,
+export async function takeAiGrant<E extends { Variables: { log: AuditableLogger } }>(
+  c: Context<E>,
   userId: string,
   route: string,
   options: { meter?: boolean } = {},
 ): Promise<AiGrant | Response> {
+  const log = c.get("log");
   let resolved: Awaited<ReturnType<typeof resolveModel>>;
   try {
     resolved = await resolveModel(userId);

--- a/apps/server/src/lib/dodo/subscription-sync.ts
+++ b/apps/server/src/lib/dodo/subscription-sync.ts
@@ -6,19 +6,19 @@
  * an event *means* for entitlement. They change for unrelated reasons -- a Dodo
  * API shape change touches this file, a Standard Webhooks change touches that one.
  *
- * Only the webhook handler should call these. Entitlement follows what Dodo says
- * happened, never what a client claims.
+ * Two callers only: the webhook handler, and `POST /api/billing/reconcile` (the
+ * post-checkout confirmation, which verifies ownership against Dodo's copy before
+ * calling in). Entitlement follows what Dodo says happened, never what a client
+ * claims -- which is why neither caller passes anything a browser supplied.
  */
 import { and, db, eq, sql } from "@OpenDiagram/db";
 import { user } from "@OpenDiagram/db/schema/auth";
 import { subscription, type SubscriptionStatus } from "@OpenDiagram/db/schema/subscription";
 import type { Refund } from "dodopayments/resources/refunds";
 import type { Subscription } from "dodopayments/resources/subscriptions";
-import { createLogger } from "evlog";
+import type { AuditableLogger } from "evlog";
 import { exhaustCreationQuota, getUserActor } from "../quota";
 import { dodoClient, planIdForProduct } from "./client";
-
-const log = createLogger({ module: "dodo-sync" });
 
 /**
  * Resolves the Dodo customer back to our user.
@@ -40,24 +40,47 @@ async function resolveUserId(data: Subscription): Promise<string | null> {
   return row?.id ?? null;
 }
 
-export async function upsertSubscription(data: Subscription, eventAt: Date): Promise<void> {
+/** Returns null once the row mirrors Dodo, or the reason it was left untouched. */
+export async function upsertSubscription(
+  data: Subscription,
+  eventAt: Date,
+  log: AuditableLogger,
+  /**
+   * `insertOnly` writes the row only when none exists, and touches nothing when
+   * one does. It is for the post-checkout reconcile, which reads a snapshot with
+   * no provider timestamp attached: any watermark it invents is either in our
+   * clock domain (and can then out-rank a genuinely later webhook when our clock
+   * runs ahead of Dodo's) or is `created_at` (and is then out-ranked by every
+   * webhook the subscription will ever emit). Not competing at all is the way out
+   * -- reconcile exists to grant the *initial* entitlement, and once a row exists
+   * the webhook has already spoken.
+   */
+  options: { insertOnly?: boolean } = {},
+): Promise<string | null> {
   const userId = await resolveUserId(data);
   if (!userId) {
     // Not an error we can retry out of, so don't 500 and invite Dodo to hammer
     // us: record it and move on. A subscription we can't attribute is a support
-    // ticket, not a transient failure.
+    // ticket, not a transient failure. The returned reason is what stops it
+    // being filed as a successful sync.
     log.warn("Dodo subscription could not be matched to a user", {
       dodo: { subscriptionId: data.subscription_id, email: data.customer.email },
     });
-    return;
+    return "subscription could not be matched to a user";
   }
 
   const planId = planIdForProduct(data.product_id);
   if (!planId) {
-    log.warn("Dodo subscription references an unknown product", {
-      dodo: { subscriptionId: data.subscription_id, productId: data.product_id },
-    });
-    return;
+    // Thrown, not returned as a skip. Unlike an unattributable user this is a
+    // *configuration* fault -- the live-mode shape of it is a wrong
+    // `DODO_PRO_PRODUCT_ID`, which hits every payer -- and it is fixable by
+    // editing an env var. Marking it processed would strand every affected
+    // subscription: the fix would land and the redelivery, including a manual
+    // replay from the Dodo dashboard, would short-circuit as a duplicate.
+    // Throwing keeps `processedAt` null, so a retry re-runs the handler.
+    throw new Error(
+      `Dodo subscription ${data.subscription_id} references unknown product ${data.product_id}`,
+    );
   }
 
   const row = {
@@ -74,6 +97,14 @@ export async function upsertSubscription(data: Subscription, eventAt: Date): Pro
     lastEventAt: eventAt,
     recurringAmountCents: data.recurring_pre_tax_amount,
   };
+
+  if (options.insertOnly) {
+    await db.insert(subscription).values(row).onConflictDoNothing({ target: subscription.id });
+    log.info("Dodo subscription seeded", {
+      dodo: { subscriptionId: data.subscription_id, status: row.status, planId },
+    });
+    return null;
+  }
 
   await db
     .insert(subscription)
@@ -98,6 +129,7 @@ export async function upsertSubscription(data: Subscription, eventAt: Date): Pro
   log.info("Dodo subscription synced", {
     dodo: { subscriptionId: data.subscription_id, status: row.status, planId },
   });
+  return null;
 }
 
 /**
@@ -112,9 +144,13 @@ export async function upsertSubscription(data: Subscription, eventAt: Date): Pro
  * A failed lookup throws, which the webhook route turns into a 500 so Dodo retries.
  * Guessing the subscription is worse than being redelivered.
  */
-export async function clawback(refund: Refund, eventAt: Date): Promise<void> {
+export async function clawback(
+  refund: Refund,
+  eventAt: Date,
+  log: AuditableLogger,
+): Promise<string | null> {
   const client = dodoClient();
-  if (!client) return;
+  if (!client) return "billing is not configured";
 
   // A partial refund is a goodwill gesture or a proration, not an unwind of the sale.
   // Ending the period and burning the fallback window over one would take the whole
@@ -123,7 +159,8 @@ export async function clawback(refund: Refund, eventAt: Date): Promise<void> {
     log.info("Dodo partial refund leaves entitlement in place", {
       dodo: { paymentId: refund.payment_id, refundId: refund.refund_id },
     });
-    return;
+    // Intentional and correct, not a skip worth flagging.
+    return null;
   }
 
   const payment = await client.payments.retrieve(refund.payment_id);
@@ -133,7 +170,7 @@ export async function clawback(refund: Refund, eventAt: Date): Promise<void> {
     log.info("Dodo refund was not for a subscription payment", {
       dodo: { paymentId: refund.payment_id },
     });
-    return;
+    return null;
   }
   const subscriptionId = payment.subscription_id;
 
@@ -170,7 +207,7 @@ export async function clawback(refund: Refund, eventAt: Date): Promise<void> {
     log.warn("Dodo refund matched no subscription to claw back", {
       dodo: { subscriptionId, paymentId: refund.payment_id },
     });
-    return;
+    return `refund matched no subscription (${subscriptionId})`;
   }
 
   for (const { userId } of rows) {
@@ -189,4 +226,5 @@ export async function clawback(refund: Refund, eventAt: Date): Promise<void> {
     await exhaustCreationQuota(actor);
     log.info("Dodo refund clawback applied", { dodo: { subscriptionId }, userId });
   }
+  return null;
 }

--- a/apps/server/src/lib/repo-generation.ts
+++ b/apps/server/src/lib/repo-generation.ts
@@ -7,7 +7,28 @@ import { generateArchitectureDoc, generateDiagramSpec, type AiCallOptions } from
 import { getProjectMemoryContext } from "./project-memory";
 import { createLogger } from "evlog";
 
-const log = createLogger({ module: "repo-generation" });
+/**
+ * Repo generation spans several requests plus a detached run, so there is no one
+ * request logger to hang these on. A module-level `createLogger()` is the wrong
+ * shape too: it is a unit-of-work accumulator that writes nothing until `emit()`,
+ * so as a long-lived singleton it dropped every line below and grew its buffer
+ * for the life of the process. Each notice is its own event instead, emitted on
+ * the spot, which keeps all the call sites below unchanged.
+ */
+const log = {
+  info(message: string, fields?: Record<string, unknown>) {
+    // `module` last: a caller's `fields` must not be able to rename the module.
+    const entry = createLogger({ ...fields, module: "repo-generation" });
+    entry.info(message);
+    entry.emit();
+  },
+  error(message: string, fields?: Record<string, unknown>) {
+    // `module` last: a caller's `fields` must not be able to rename the module.
+    const entry = createLogger({ ...fields, module: "repo-generation" });
+    entry.error(message);
+    entry.emit();
+  },
+};
 
 type RepoGenerationStatus = "queued" | "planning" | "creating" | "generating" | "done" | "failed";
 type RepoGenerationTaskStatus = "pending" | "active" | "complete" | "failed";

--- a/apps/server/src/lib/require-auth.ts
+++ b/apps/server/src/lib/require-auth.ts
@@ -2,7 +2,11 @@ import { auth } from "@OpenDiagram/auth";
 import type { EvlogVariables } from "evlog/hono";
 import { createMiddleware } from "hono/factory";
 
-export type AuthVariables = EvlogVariables & {
+// `EvlogVariables` is already wrapped (`{ Variables: { log } }`), and every call
+// site spells `new Hono<{ Variables: AuthVariables }>()`. Spreading the wrapper
+// itself would nest it a second time and hide `log` behind `c.get("Variables")`,
+// so unwrap it here -- that is what makes `c.get("log")` typed on auth routes.
+export type AuthVariables = EvlogVariables["Variables"] & {
   userId: string;
 };
 

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -12,14 +12,15 @@ import { and, db, eq, inArray, sql } from "@OpenDiagram/db";
 import { user } from "@OpenDiagram/db/schema/auth";
 import { ENTITLING_SUBSCRIPTION_STATUSES, subscription } from "@OpenDiagram/db/schema/subscription";
 import { env } from "@OpenDiagram/env/server";
-import { createLogger } from "evlog";
 import { Hono } from "hono";
 import { z } from "zod";
 import { appOrigin, billingEnabled, dodoClient } from "../lib/dodo";
+// Deliberately not via the `dodo` barrel: keeping this import explicit is what
+// stops an arbitrary route picking up a writer for the `subscription` table.
+// Only the webhook and `POST /reconcile` below may call it.
+import { upsertSubscription } from "../lib/dodo/subscription-sync";
 import { getPlan, getUserActor } from "../lib/quota";
 import { type AuthVariables, requireAuth } from "../lib/require-auth";
-
-const log = createLogger({ module: "billing" });
 
 const checkoutSchema = z.object({
   /** Optional promo code, e.g. LAUNCH. Dodo validates and rejects it, not us. */
@@ -66,6 +67,7 @@ billingRoute.get("/", async (c) => {
 });
 
 billingRoute.post("/checkout", async (c) => {
+  const log = c.get("log");
   const client = dodoClient();
   // `DODO_PRO_PRODUCT_ID` is re-checked rather than left to billingEnabled() so it
   // narrows to a string for the product_cart below.
@@ -143,6 +145,7 @@ billingRoute.post("/checkout", async (c) => {
 
 /** Dodo-hosted portal: cancel, resume, update the payment method, get invoices. */
 billingRoute.post("/portal", async (c) => {
+  const log = c.get("log");
   const client = dodoClient();
   if (!client) return c.json({ error: "Billing is not configured." }, 404);
 
@@ -167,4 +170,113 @@ billingRoute.post("/portal", async (c) => {
     log.error("Dodo customer portal failed", { error });
     return c.json({ error: "Could not open the billing portal." }, 502);
   }
+});
+
+const reconcileSchema = z.object({
+  /** Dodo appends this to `return_url` itself; it is untrusted input all the same. */
+  subscriptionId: z.string().trim().min(1).max(128),
+});
+
+/**
+ * Second path to entitlement, for the moment the buyer is standing on the return
+ * page waiting for Pro to appear.
+ *
+ * The webhook stays the authority -- it is the only thing that covers renewals,
+ * cancellations and refunds, and the only thing that fires when the customer
+ * closes the tab before redirecting. But it is also a single point of failure at
+ * the one moment a user is watching, and a lost delivery means money taken and
+ * nothing granted. Both Stripe and Dodo prescribe running the two together:
+ * Dodo's FAQ is "always listen for the webhook OR query the API to confirm the
+ * transaction after redirect", and Stripe labels the landing-page path
+ * "Recommended" for exactly this reason.
+ *
+ * Two rules make it safe to have a second writer:
+ *
+ * 1. **The query parameter proves nothing.** Dodo's own guidance is to treat a
+ *    redirect as a user-facing confirmation, not proof of payment -- the params
+ *    are trivially forged. So the id is only ever used to *look up* the truth from
+ *    Dodo, and the subscription is then checked to actually belong to the caller.
+ *    Without that check this endpoint would hand anyone Pro for a guessed id.
+ * 2. **It converges with the webhook rather than racing it.** It calls the same
+ *    `upsertSubscription`, so the same `lastEventAt` ordering guard applies and
+ *    whichever path lands second is a no-op.
+ */
+billingRoute.post("/reconcile", async (c) => {
+  const log = c.get("log");
+  const client = dodoClient();
+  if (!client) return c.json({ error: "Billing is not configured." }, 404);
+
+  const userId = c.get("userId");
+  const parsed = reconcileSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) return c.json({ error: "Invalid request" }, 400);
+  const { subscriptionId } = parsed.data;
+
+  let remote: Awaited<ReturnType<typeof client.subscriptions.retrieve>>;
+  try {
+    remote = await client.subscriptions.retrieve(subscriptionId);
+  } catch (error) {
+    // A forged or stale id lands here. Nothing is written and nothing is leaked
+    // about whether the id exists.
+    log.warn("Post-checkout reconcile could not load the subscription", {
+      dodo: { subscriptionId },
+      error,
+    });
+    return c.json({ error: "Could not confirm the subscription." }, 404);
+  }
+
+  // Ownership, from Dodo's copy rather than the caller's claim, and on
+  // `metadata.userId` ONLY.
+  //
+  // `upsertSubscription` also accepts an email match, which is right for the
+  // webhook: it has to attribute a subscription created straight from the Dodo
+  // dashboard. Here it would be an account-takeover primitive. Email verification
+  // is a soft gate (HANDOVER.md §3.7), so anyone can hold an unverified account on
+  // an address they don't own -- and matching on it would let them claim the
+  // subscription of a customer who paid but never signed up. There is no cost to
+  // dropping it: this path only ever runs after *our* checkout, which always
+  // stamps `metadata.userId`.
+  //
+  // Dodo types metadata values as string | number | boolean, so narrow first.
+  const claimedBy = remote.metadata?.userId;
+  if (typeof claimedBy !== "string" || claimedBy !== userId) {
+    log.warn("Post-checkout reconcile rejected: subscription is not the caller's", {
+      dodo: { subscriptionId },
+      userId,
+    });
+    // Same 404 and body as an unknown id above, deliberately: distinguishing
+    // "exists but not yours" from "does not exist" turns this into an oracle for
+    // probing which subscription ids are real.
+    return c.json({ error: "Could not confirm the subscription." }, 404);
+  }
+
+  // `insertOnly`, so this write never competes with the webhook for ordering. The
+  // snapshot carries no provider timestamp -- `created_at` dates the subscription,
+  // not the read -- so any watermark this could invent is wrong in one direction
+  // or the other: our own clock can run ahead of Dodo's and suppress a genuinely
+  // later cancellation, and `created_at` is older than every webhook the
+  // subscription will ever emit. Seeding only when no row exists sidesteps the
+  // choice: reconcile grants the initial entitlement, and the moment a row exists
+  // the webhook owns it. `created_at` is still passed so the seeded watermark
+  // stays in Dodo's clock domain.
+  let skipped: string | null;
+  try {
+    skipped = await upsertSubscription(remote, new Date(remote.created_at), log, {
+      insertOnly: true,
+    });
+  } catch (error) {
+    // `upsertSubscription` throws on an unknown product, which is a misconfigured
+    // `DODO_PRO_PRODUCT_ID` -- our fault, not the caller's. Without this the throw
+    // reaches Hono's global handler with no billing-level log, and every reconcile
+    // 500s with nothing saying why.
+    log.error("Post-checkout reconcile failed", { dodo: { subscriptionId }, error });
+    return c.json({ error: "Could not confirm the subscription." }, 502);
+  }
+  if (skipped) {
+    log.warn("Post-checkout reconcile did not apply", { dodo: { subscriptionId, skipped } });
+    return c.json({ error: "Could not confirm the subscription." }, 409);
+  }
+
+  const actor = await getUserActor(userId);
+  log.info("Post-checkout reconcile applied", { dodo: { subscriptionId }, plan: actor.planId });
+  return c.json({ planId: actor.planId, status: remote.status });
 });

--- a/apps/server/src/routes/github.ts
+++ b/apps/server/src/routes/github.ts
@@ -9,7 +9,6 @@ import type { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import { createLogger } from "evlog";
 
-const log = createLogger({ module: "github-import" });
 import { indexRepositoryMemory } from "../lib/project-memory";
 import { peekCreationQuotaActor } from "../lib/quota";
 import { cleanupRepositoryClone, cloneAndBuildRepositoryDoc } from "../lib/repo-documentation";
@@ -315,6 +314,14 @@ async function runImportJob(input: { jobId: string; repo: GitHubRepository; toke
   if (!job) return;
   let repoPathToCleanup: string | null = null;
 
+  // An import job is its own unit of work, outliving nothing but owning enough
+  // steps to deserve one wide event. `createLogger` accumulates and only writes
+  // on `emit()` -- which the `finally` below guarantees, however this exits.
+  const log = createLogger({
+    module: "github-import",
+    job: { id: job.id, repo: input.repo.full_name },
+  });
+
   try {
     const importedAt = new Date().toISOString();
     await updateImportJob(job.id, { status: "cloning", message: "Cloning repository to server" });
@@ -398,6 +405,7 @@ async function runImportJob(input: { jobId: string; repo: GitHubRepository; toke
         log.error("Failed to clean up repository clone", { error });
       });
     }
+    log.emit();
   }
 }
 

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -21,8 +21,6 @@ import {
 import { type AuthVariables, requireAuth } from "../lib/require-auth";
 import { createLogger } from "evlog";
 
-const log = createLogger({ module: "projects" });
-
 const createSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
@@ -69,7 +67,11 @@ const contextQuerySchema = z.object({
 
 function markProjectMemoryPendingSafely(projectId: string, userId: string) {
   void markProjectMemoryPending(projectId, userId).catch((error) => {
+    // Detached from the request on purpose, so it can outlive the response and
+    // the request logger that is sealed with it. Its own event, emitted here.
+    const log = createLogger({ module: "projects", project: { id: projectId }, userId });
     log.error("Failed to mark project memory pending", { error });
+    log.emit();
   });
 }
 

--- a/apps/server/src/routes/webhooks/dodo.ts
+++ b/apps/server/src/routes/webhooks/dodo.ts
@@ -21,16 +21,20 @@
 import { db, eq } from "@OpenDiagram/db";
 import { webhookEvent } from "@OpenDiagram/db/schema/webhook-event";
 import type { UnwrapWebhookEvent } from "dodopayments/resources/webhooks/webhooks";
-import { createLogger } from "evlog";
+import type { AuditableLogger } from "evlog";
+import type { EvlogVariables } from "evlog/hono";
 import { Hono } from "hono";
 import { dodoClient } from "../../lib/dodo";
 import { clawback, upsertSubscription } from "../../lib/dodo/subscription-sync";
 
-const log = createLogger({ module: "dodo-webhook" });
-
-export const dodoWebhookRoute = new Hono();
+export const dodoWebhookRoute = new Hono<EvlogVariables>();
 
 dodoWebhookRoute.post("/", async (c) => {
+  // The request logger, not a module-level `createLogger()`. That returns a
+  // unit-of-work accumulator that only writes on `.emit()`, so a module-scoped
+  // one never emits: every line below would go nowhere, including the signature
+  // failure that is the sole signal a paying user was silently not upgraded.
+  const log = c.get("log");
   const client = dodoClient();
   // Billing unconfigured is the self-host default, and a 404 says so honestly
   // rather than pretending to accept events we can't verify.
@@ -82,30 +86,44 @@ dodoWebhookRoute.post("/", async (c) => {
     log.warn("Retrying a Dodo webhook whose earlier attempt failed");
   }
 
+  let skipped: string | null;
   try {
     // Concurrent deliveries of the same event can both reach this. That's safe:
     // the subscription upsert is idempotent and guarded on `lastEventAt`.
-    await handleEvent(event);
+    skipped = await handleEvent(event, log);
   } catch (error) {
+    // Read the cause out BEFORE logging. evlog rewrites the message of an Error
+    // passed as a field to the log's own message, so reading it afterwards stores
+    // "Dodo webhook handler failed" for every failure and loses the one detail
+    // this column exists to keep.
+    const reason = error instanceof Error ? error.message : String(error);
     log.error("Dodo webhook handler failed", { error });
     // Kept, with the reason, so a stuck event is greppable. `processedAt` stays
     // null, so Dodo's retry will run the handler again rather than short-circuit.
-    await db
-      .update(webhookEvent)
-      .set({ error: error instanceof Error ? error.message : String(error) })
-      .where(eq(webhookEvent.id, webhookId));
+    await db.update(webhookEvent).set({ error: reason }).where(eq(webhookEvent.id, webhookId));
     return c.json({ error: "Webhook processing failed" }, 500);
   }
 
+  // `processedAt` is set either way, so a permanently unapplicable event isn't
+  // redelivered forever -- but a skip reason is recorded rather than being
+  // indistinguishable from a real sync. `processed_at IS NOT NULL AND error IS
+  // NOT NULL` is exactly "accepted, deliberately not applied"; the failure path
+  // above is the opposite pair and still invites a retry.
+  if (skipped) log.warn("Dodo webhook accepted but not applied", { dodo: { skipped } });
+
   await db
     .update(webhookEvent)
-    .set({ processedAt: new Date(), error: null })
+    .set({ processedAt: new Date(), error: skipped })
     .where(eq(webhookEvent.id, webhookId));
 
   return c.json({ received: true });
 });
 
-async function handleEvent(event: UnwrapWebhookEvent): Promise<void> {
+/** Returns null when the event was applied, or the reason it deliberately wasn't. */
+async function handleEvent(
+  event: UnwrapWebhookEvent,
+  log: AuditableLogger,
+): Promise<string | null> {
   const eventAt = new Date(event.timestamp);
 
   switch (event.type) {
@@ -120,8 +138,7 @@ async function handleEvent(event: UnwrapWebhookEvent): Promise<void> {
     case "subscription.failed":
     case "subscription.cancelled":
     case "subscription.expired":
-      await upsertSubscription(event.data, eventAt);
-      return;
+      return await upsertSubscription(event.data, eventAt, log);
 
     // Log-only, for reconciling our ledger against Dodo payouts. Entitlement
     // never moves on a payment event: `subscription.*` is the authority, and
@@ -131,16 +148,15 @@ async function handleEvent(event: UnwrapWebhookEvent): Promise<void> {
       log.info("Dodo payment event", {
         dodo: { paymentId: event.data.payment_id, amount: event.data.total_amount },
       });
-      return;
+      return null;
 
     // Money went back, so access and credits go with it, immediately -- not at
     // period end the way a cancellation does.
     case "refund.succeeded":
-      await clawback(event.data, eventAt);
-      return;
+      return await clawback(event.data, eventAt, log);
 
     default:
       log.info("Unhandled Dodo webhook event");
-      return;
+      return null;
   }
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { GuestWelcomeDialog } from "@/components/auth/guest-welcome-dialog";
+import { CheckoutReturn } from "@/components/billing/checkout-return";
 import { DashboardDialogs } from "@/components/dashboard/dashboard-page/DashboardDialogs";
 import { DashboardMain } from "@/components/dashboard/dashboard-page/DashboardMain";
 import { DashboardSidebar } from "@/components/dashboard/dashboard-page/DashboardSidebar";
@@ -46,6 +47,10 @@ export default function DashboardPage() {
 
   return (
     <main className="h-dvh overflow-hidden bg-od-surface text-od-ink">
+      {/* Suspense because it reads search params, which Next requires a boundary for. */}
+      <Suspense fallback={null}>
+        <CheckoutReturn />
+      </Suspense>
       <div className="flex h-full w-full overflow-hidden">
         <DashboardSidebar
           accountId={user?.id}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Instrument_Serif } from "next/font/google";
 import localFont from "next/font/local";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Toaster } from "sonner";
 import "./globals.css";
 import {
   assetUrl,
@@ -72,6 +73,9 @@ export default function RootLayout({
     >
       <body className="antialiased">
         {children}
+        {/* sonner renders nothing without this. It was never mounted, so every
+            existing `toast.*` call in the dashboard was silently a no-op. */}
+        <Toaster position="bottom-right" richColors />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/apps/web/src/components/billing/checkout-return.tsx
+++ b/apps/web/src/components/billing/checkout-return.tsx
@@ -18,6 +18,12 @@ import { reconcileCheckout } from "@/lib/billing-client";
  * the subscription from Dodo and verifies it belongs to the session before writing.
  * The webhook remains the authority for everything after this moment.
  */
+/**
+ * Statuses that mean this purchase is over, so there is nothing left to wait for.
+ * `pending` is deliberately absent -- that one really does resolve on the webhook.
+ */
+const TERMINAL_STATUSES = new Set(["failed", "expired", "cancelled"]);
+
 export function CheckoutReturn() {
   const router = useRouter();
   const params = useSearchParams();
@@ -50,13 +56,21 @@ export function CheckoutReturn() {
     }
 
     void reconcileCheckout(subscriptionId)
-      .then((planId) => {
+      .then(({ planId, status }) => {
         if (!live) return;
         if (planId === "pro") {
           toast.success("You're on Pro.", { description: "Your credits have been topped up." });
+        } else if (TERMINAL_STATUSES.has(status)) {
+          // Nothing is coming. Dodo's `failed` means the mandate could not be
+          // created at all, and it is not recoverable -- the customer has to start
+          // a new subscription. Saying "confirming shortly" here leaves someone
+          // waiting for an upgrade that will never arrive.
+          toast.error("That payment didn't go through.", {
+            description: "No charge was made. You can try again with another payment method.",
+          });
         } else {
-          // Payment went through but entitlement hasn't landed -- almost always the
-          // subscription still being `pending` at Dodo. The webhook will finish it.
+          // Still `pending` at Dodo. This one really is a wait -- the webhook
+          // finishes it.
           toast.info("Payment received.", {
             description: "Your upgrade is being confirmed and will appear shortly.",
           });

--- a/apps/web/src/components/billing/checkout-return.tsx
+++ b/apps/web/src/components/billing/checkout-return.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { reconcileCheckout } from "@/lib/billing-client";
+
+/**
+ * Closes the gap between paying and being Pro.
+ *
+ * Dodo appends `subscription_id` and `status` to the `return_url` it sends the
+ * buyer back to. Until this existed nothing read them, so entitlement arrived only
+ * when the webhook did -- and a lost delivery meant the buyer landed here, still on
+ * Free, with no way to tell that anything had gone wrong. That happened in test mode
+ * and it cost a duplicate subscription, because the upgrade button was still live.
+ *
+ * The id is not proof of anything and is not treated as such: the server re-reads
+ * the subscription from Dodo and verifies it belongs to the session before writing.
+ * The webhook remains the authority for everything after this moment.
+ */
+export function CheckoutReturn() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const subscriptionId = params.get("subscription_id");
+  const isCheckoutReturn = params.get("checkout") === "success" || Boolean(subscriptionId);
+  // React strict mode mounts effects twice in dev, and the reconcile is a POST.
+  // It is idempotent server-side, but firing it twice would double the toast.
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (!isCheckoutReturn || handled.current) return;
+    handled.current = true;
+
+    // The reconcile is a network round-trip and the user may leave before it
+    // lands. Without this, a late `clear()` yanks them back to the dashboard from
+    // wherever they navigated to.
+    let live = true;
+
+    // Strip the billing params either way, so a refresh or a shared URL doesn't
+    // replay this and the address bar doesn't keep a payment id in history.
+    const clear = () => {
+      if (live) router.replace("/dashboard");
+    };
+
+    if (!subscriptionId) {
+      // Came back without an id (a one-time payment, or Dodo changed the params).
+      // The webhook is still on its way; say nothing rather than something wrong.
+      clear();
+      return;
+    }
+
+    void reconcileCheckout(subscriptionId)
+      .then((planId) => {
+        if (!live) return;
+        if (planId === "pro") {
+          toast.success("You're on Pro.", { description: "Your credits have been topped up." });
+        } else {
+          // Payment went through but entitlement hasn't landed -- almost always the
+          // subscription still being `pending` at Dodo. The webhook will finish it.
+          toast.info("Payment received.", {
+            description: "Your upgrade is being confirmed and will appear shortly.",
+          });
+        }
+      })
+      .catch(() => {
+        if (!live) return;
+        // Never claim failure: the money may well have been taken and the webhook
+        // may still land. Point at the page that reads the real state.
+        toast.info("Payment received.", {
+          description: "Your upgrade is being confirmed and will appear shortly.",
+        });
+      })
+      .finally(() => {
+        if (!live) return;
+        // Refresh on the error path too: the webhook may already have granted Pro
+        // before the reconcile failed, and without this the page keeps rendering
+        // Free until the user reloads by hand.
+        router.refresh();
+        clear();
+      });
+
+    return () => {
+      live = false;
+      // Released so a remount can try again. Without this, React Strict Mode's
+      // setup/cleanup/setup would leave the only attempt marked dead by the
+      // cleanup and the second setup barred by the ref, so a dev checkout return
+      // would silently do nothing. Harmless in production, where the effect runs
+      // once; the reconcile is idempotent either way.
+      handled.current = false;
+    };
+  }, [isCheckoutReturn, subscriptionId, router]);
+
+  return null;
+}

--- a/apps/web/src/lib/billing-client.ts
+++ b/apps/web/src/lib/billing-client.ts
@@ -45,7 +45,11 @@ export async function startCheckout(discountCode?: string): Promise<string> {
  * The id comes from Dodo's own `return_url` params; the server re-reads it from
  * Dodo and checks ownership, so nothing here is trusted.
  */
-export async function reconcileCheckout(subscriptionId: string): Promise<BillingState["planId"]> {
+export async function reconcileCheckout(subscriptionId: string): Promise<{
+  planId: BillingState["planId"];
+  /** Dodo's subscription status. Needed to tell "not yet" apart from "never". */
+  status: NonNullable<BillingState["subscription"]>["status"];
+}> {
   const response = await fetch(`${BASE}/reconcile`, {
     method: "POST",
     credentials: "include",
@@ -53,8 +57,7 @@ export async function reconcileCheckout(subscriptionId: string): Promise<Billing
     body: JSON.stringify({ subscriptionId }),
   });
   if (!response.ok) throw new Error(await readError(response, "Could not confirm your upgrade."));
-  const { planId } = (await response.json()) as { planId: BillingState["planId"] };
-  return planId;
+  return response.json();
 }
 
 /** Returns the Dodo-hosted portal URL: cancel, resume, card, invoices. */

--- a/apps/web/src/lib/billing-client.ts
+++ b/apps/web/src/lib/billing-client.ts
@@ -40,6 +40,23 @@ export async function startCheckout(discountCode?: string): Promise<string> {
   return checkoutUrl;
 }
 
+/**
+ * Confirms a just-completed checkout so Pro appears without waiting on the webhook.
+ * The id comes from Dodo's own `return_url` params; the server re-reads it from
+ * Dodo and checks ownership, so nothing here is trusted.
+ */
+export async function reconcileCheckout(subscriptionId: string): Promise<BillingState["planId"]> {
+  const response = await fetch(`${BASE}/reconcile`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ subscriptionId }),
+  });
+  if (!response.ok) throw new Error(await readError(response, "Could not confirm your upgrade."));
+  const { planId } = (await response.json()) as { planId: BillingState["planId"] };
+  return planId;
+}
+
 /** Returns the Dodo-hosted portal URL: cancel, resume, card, invoices. */
 export async function openBillingPortal(): Promise<string> {
   const response = await fetch(`${BASE}/portal`, {


### PR DESCRIPTION
 A real test-mode payment did not upgrade the account, and nothing anywhere said so. The cause was environmental - the registered tunnel hostname stopped resolving, so no webhook was ever delivered - but chasing it surfaced three defects that would each be worse in live mode.

 - Every log line in the billing path was a no-op. createLogger() only writes on .emit(), and seven modules held one at module scope. Because the drain forwards to Sentry only at warn/error, a dead logger left the wide event at info - so the webhook signature-failure alert could never have fired. Now c.get("log"), passed down explicitly (Hono has no useLogger()/fork()).
 - An event that could never be applied reported success. Unresolvable user or unknown product returned void, processedAt was set anyway, and the redelivery short-circuited as a duplicate. Now records a skip reason - the exact shape a wrong live-mode product id takes.
 - The webhook was the only path to entitlement. Added POST /api/billing/reconcile, the redirect confirmation both Dodo and Stripe prescribe alongside webhooks. Ownership verified against Dodo on metadata.userId only; converges with the webhook through the same ordering guard.

Verified by running against real Dodo test-mode subscriptions, not by reading: reconcile grants Pro with the row deleted first; foreign and forged ids both 404 identically; reconcile and a late webhook converge on one row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Dodo billing resilient: upgrades now appear on return from checkout even if the webhook is lost, logs/errors are surfaced, and failed checkouts are shown immediately instead of “wait” messaging.

- **New Features**
  - Added `POST /api/billing/reconcile`: re-reads the subscription from Dodo, verifies ownership on `metadata.userId`, and seeds entitlement insert-only so it never races the webhook; unknown/foreign ids 404 identically.
  - Dashboard `CheckoutReturn` reads `subscription_id`, calls reconcile, strips params, refreshes state, avoids acting after navigation, and shows toasts; mounted `<Toaster />` so existing `toast.*` calls render.

- **Bug Fixes**
  - Replaced dead module-scoped loggers with the request logger from `c.get("log")`; long-lived jobs now create and emit their own events; fixed `AuthVariables` typing so `log` is available on auth routes.
  - Webhook processing now stores skip reasons in `webhook_event.error`; unknown product ids throw so `processedAt` stays null and Dodo retries; reconcile seeds only when missing, so it never competes with the webhook or suppresses later events.
  - Checkout return now uses Dodo `status` to tell failures (`failed`/`expired`/`cancelled`) from slow (`pending`), showing an error only for terminal cases; only `pending` shows “will appear shortly.”

<sup>Written for commit 810bc6b0b07762c5c064b30fc3b24e7f8c0f51c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

