### PR TITLE
fix(billing): close the discount, chargeback and refund holes before live mode

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,12 @@ import { dodoWebhookRoute } from "./routes/webhooks/dodo";
 
 initLogger({
   env: { service: "OpenDiagram-server" },
+  // Explicit, though evlog already defaults this to on in production and the
+  // Dockerfile does set NODE_ENV=production. The billing path logs a customer
+  // email (lib/dodo/subscription-sync.ts), and those events reach Sentry, so
+  // whether that address is masked should not rest on an ENV line in a
+  // Dockerfile that a future deploy target may not reproduce.
+  redact: true,
 });
 
 const identifyUser = createAuthMiddleware(auth as BetterAuthInstance, {

--- a/apps/server/src/lib/dodo/subscription-sync.ts
+++ b/apps/server/src/lib/dodo/subscription-sync.ts
@@ -13,7 +13,12 @@
  */
 import { and, db, eq, sql } from "@OpenDiagram/db";
 import { user } from "@OpenDiagram/db/schema/auth";
-import { subscription, type SubscriptionStatus } from "@OpenDiagram/db/schema/subscription";
+import {
+  subscription,
+  subscriptionStatuses,
+  type SubscriptionStatus,
+} from "@OpenDiagram/db/schema/subscription";
+import type { Dispute } from "dodopayments/resources/disputes";
 import type { Refund } from "dodopayments/resources/refunds";
 import type { Subscription } from "dodopayments/resources/subscriptions";
 import type { AuditableLogger } from "evlog";
@@ -83,6 +88,16 @@ export async function upsertSubscription(
     );
   }
 
+  // Validated, not cast. `text(..., { enum })` is a TypeScript-only constraint --
+  // there is no CHECK on this column (confirmed against the live database) -- so a
+  // status Dodo adds later would be written straight through, land outside
+  // `ENTITLING_SUBSCRIPTION_STATUSES`, and silently de-entitle a paying customer.
+  // Throwing instead takes the same path as an unknown product: `processedAt` stays
+  // null, so the event is redelivered once the new status is understood.
+  if (!(subscriptionStatuses as readonly string[]).includes(data.status)) {
+    throw new Error(`Dodo subscription ${data.subscription_id} has unknown status ${data.status}`);
+  }
+
   const row = {
     id: data.subscription_id,
     userId,
@@ -123,7 +138,16 @@ export async function upsertSubscription(
       },
       // The ordering guard: a redelivered older event is dropped rather than
       // rolling a cancellation back to active.
-      where: sql`${subscription.lastEventAt} <= ${eventAt.toISOString()}`,
+      //
+      // `setWhere`, not `where`. Both currently emit the same
+      // `DO UPDATE SET ... WHERE` clause -- verified by generating the SQL -- but
+      // `where` is @deprecated in drizzle 0.45.2 in favour of an explicit
+      // `targetWhere`/`setWhere` split. The two mean very different things: on the
+      // conflict target this would be an index predicate, not a guard on the row
+      // being overwritten. Naming it explicitly means a future drizzle release
+      // cannot quietly reinterpret the clause that stops a replayed
+      // `subscription.active` resurrecting a cancelled subscription.
+      setWhere: sql`${subscription.lastEventAt} <= ${eventAt.toISOString()}`,
     });
 
   log.info("Dodo subscription synced", {
@@ -152,18 +176,31 @@ export async function clawback(
   const client = dodoClient();
   if (!client) return "billing is not configured";
 
+  const payment = await client.payments.retrieve(refund.payment_id);
+
   // A partial refund is a goodwill gesture or a proration, not an unwind of the sale.
   // Ending the period and burning the fallback window over one would take the whole
   // month's access away for a few dollars back.
-  if (refund.is_partial) {
+  //
+  // Two signals, either of which means the sale is fully unwound, because neither
+  // alone is sufficient. `refund.is_partial` is Dodo's classification of *this*
+  // refund, so a payment refunded in two partial instalments is never `false` on
+  // either one and would keep entitlement forever. `payment.refund_status` is the
+  // running total on the payment and catches that, but it is optional in the SDK
+  // (`'partial' | 'full' | undefined`), so it cannot be the only test either.
+  const fullyRefunded = payment.refund_status === "full" || refund.is_partial === false;
+  if (!fullyRefunded) {
     log.info("Dodo partial refund leaves entitlement in place", {
-      dodo: { paymentId: refund.payment_id, refundId: refund.refund_id },
+      dodo: {
+        paymentId: refund.payment_id,
+        refundId: refund.refund_id,
+        refundStatus: payment.refund_status ?? null,
+      },
     });
     // Intentional and correct, not a skip worth flagging.
     return null;
   }
 
-  const payment = await client.payments.retrieve(refund.payment_id);
   if (!payment.subscription_id) {
     // We only sell subscriptions, so a one-time payment refund has no entitlement
     // attached to reverse.
@@ -172,8 +209,52 @@ export async function clawback(
     });
     return null;
   }
-  const subscriptionId = payment.subscription_id;
+  return await revokeSubscription(payment.subscription_id, eventAt, log, {
+    paymentId: refund.payment_id,
+    cause: "refund",
+  });
+}
 
+/**
+ * A lost or accepted chargeback: the cardholder has their money back.
+ *
+ * Economically identical to a full refund, but it arrives as a `dispute.*` event
+ * and **no `refund.*` event ever fires**, so without this the clawback above never
+ * runs and the customer keeps Pro for free. Dodo's dispute docs are explicit that
+ * `dispute.lost` means "funds returned to the cardholder -- reconcile and keep
+ * access revoked", and disputes auto-resolved through Visa RDR also surface here.
+ *
+ * `Dispute` carries `payment_id` but no `subscription_id`, so it resolves the same
+ * way the refund path does.
+ */
+export async function clawbackForDispute(
+  dispute: Dispute,
+  eventAt: Date,
+  log: AuditableLogger,
+): Promise<string | null> {
+  const client = dodoClient();
+  if (!client) return "billing is not configured";
+
+  const payment = await client.payments.retrieve(dispute.payment_id);
+  if (!payment.subscription_id) {
+    log.info("Dodo dispute was not for a subscription payment", {
+      dodo: { paymentId: dispute.payment_id, disputeId: dispute.dispute_id },
+    });
+    return null;
+  }
+  return await revokeSubscription(payment.subscription_id, eventAt, log, {
+    paymentId: dispute.payment_id,
+    cause: "dispute",
+  });
+}
+
+/** Ends the period now and burns the window the user falls back onto. */
+async function revokeSubscription(
+  subscriptionId: string,
+  eventAt: Date,
+  log: AuditableLogger,
+  context: { paymentId: string; cause: "refund" | "dispute" },
+): Promise<string | null> {
   const rows = await db
     .update(subscription)
     .set({
@@ -204,10 +285,10 @@ export async function clawback(
   // Only rows this event actually updated are clawed back -- a row skipped by the
   // ordering guard keeps whatever a newer event said, credits included.
   if (rows.length === 0) {
-    log.warn("Dodo refund matched no subscription to claw back", {
-      dodo: { subscriptionId, paymentId: refund.payment_id },
+    log.warn("Dodo clawback matched no subscription", {
+      dodo: { subscriptionId, paymentId: context.paymentId, cause: context.cause },
     });
-    return `refund matched no subscription (${subscriptionId})`;
+    return `${context.cause} matched no subscription (${subscriptionId})`;
   }
 
   for (const { userId } of rows) {
@@ -215,16 +296,16 @@ export async function clawback(
     // just fell back onto rather than the Pro one they no longer have.
     const actor = await getUserActor(userId);
     if (actor.planId === "pro") {
-      // They resubscribed before this refund arrived. The refunded period is ended
+      // They resubscribed before this event arrived. The reversed period is ended
       // above, but the window they are on now is paid for and not ours to burn.
-      log.warn("Dodo refund clawback skipped: user has another paid subscription", {
-        dodo: { subscriptionId },
+      log.warn("Dodo clawback skipped: user has another paid subscription", {
+        dodo: { subscriptionId, cause: context.cause },
         userId,
       });
       continue;
     }
     await exhaustCreationQuota(actor);
-    log.info("Dodo refund clawback applied", { dodo: { subscriptionId }, userId });
+    log.info("Dodo clawback applied", { dodo: { subscriptionId, cause: context.cause }, userId });
   }
   return null;
 }

--- a/apps/server/src/lib/quota/credits.ts
+++ b/apps/server/src/lib/quota/credits.ts
@@ -83,7 +83,11 @@ async function increment(key: CounterKey, limit: number): Promise<number | null>
         creationUsage.windowStart,
       ],
       set: { count: sql`${creationUsage.count} + 1`, updatedAt: new Date() },
-      where: sql`${creationUsage.count} < ${limit}`,
+      // `setWhere`, not the @deprecated `where` -- see the note in
+      // lib/dodo/subscription-sync.ts. This clause is the entire reason parallel
+      // requests cannot both take the last credit, so it must not be able to drift
+      // onto the conflict target and become an index predicate.
+      setWhere: sql`${creationUsage.count} < ${limit}`,
     })
     .returning({ count: creationUsage.count });
   return row?.count ?? null;

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -8,7 +8,7 @@
  *
  * Both 404 when billing is unconfigured, which is the OSS self-host default.
  */
-import { and, db, eq, inArray, sql } from "@OpenDiagram/db";
+import { and, db, eq, inArray, ne, sql } from "@OpenDiagram/db";
 import { user } from "@OpenDiagram/db/schema/auth";
 import { ENTITLING_SUBSCRIPTION_STATUSES, subscription } from "@OpenDiagram/db/schema/subscription";
 import { env } from "@OpenDiagram/env/server";
@@ -19,13 +19,42 @@ import { appOrigin, billingEnabled, dodoClient } from "../lib/dodo";
 // stops an arbitrary route picking up a writer for the `subscription` table.
 // Only the webhook and `POST /reconcile` below may call it.
 import { upsertSubscription } from "../lib/dodo/subscription-sync";
-import { getPlan, getUserActor } from "../lib/quota";
+import { enforceAiBurst, getPlan, getUserActor, quotaErrorResponse } from "../lib/quota";
 import { type AuthVariables, requireAuth } from "../lib/require-auth";
 
 const checkoutSchema = z.object({
-  /** Optional promo code, e.g. LAUNCH. Dodo validates and rejects it, not us. */
+  /** Optional promo code, e.g. LAUNCH. Dodo validates the code itself; who may
+   *  redeem it is enforced here -- see `mayRedeemDiscount`. */
   discountCode: z.string().trim().min(1).max(64).optional(),
 });
+
+/**
+ * Whether this user may have a promo code applied to their checkout.
+ *
+ * This has to be our decision, because Dodo's is not enforced. Measured against
+ * the test-mode API on 2026-07-28: with `customer_eligibility: "first_time"` AND
+ * `per_customer_usage_limit: 1` set on the LAUNCH discount, a customer holding an
+ * active subscription and three prior redemptions was still shown "you're saving
+ * 37.5%" -- both when the code was pre-applied to the session and when they typed
+ * it into Dodo's hosted page themselves. Neither restriction bound. The only Dodo
+ * cap that demonstrably holds is `usage_limit`, which counts *attempts* rather
+ * than sales, so failed payments burn it too.
+ *
+ * Left alone, that is a $5 price every month for anyone willing to resubscribe.
+ *
+ * `failed` rows are deliberately not disqualifying: the mandate was never created
+ * and no money moved, so a declined card would otherwise cost a genuine buyer the
+ * launch price on their retry. Every other status -- including `cancelled` and
+ * `expired` -- means a sale completed at some point.
+ */
+async function mayRedeemDiscount(userId: string): Promise<boolean> {
+  const [prior] = await db
+    .select({ id: subscription.id })
+    .from(subscription)
+    .where(and(eq(subscription.userId, userId), ne(subscription.status, "failed")))
+    .limit(1);
+  return !prior;
+}
 
 export const billingRoute = new Hono<{ Variables: AuthVariables }>();
 
@@ -113,6 +142,27 @@ billingRoute.post("/checkout", async (c) => {
     .limit(1);
   if (!account) return c.json({ error: "Unauthorized" }, 401);
 
+  // Applied only for a user who has never completed a sale. Dodo does not enforce
+  // this itself (see `mayRedeemDiscount`), so this call is the enforcement.
+  //
+  // Refused out loud rather than dropped silently: a user who typed a code and
+  // then landed on a full-price page with no discount field -- because the branch
+  // below turns it off -- would have no way to tell whether the code failed, the
+  // page was broken, or they were being overcharged.
+  const discountCode = parsed.data.discountCode;
+  if (discountCode && !(await mayRedeemDiscount(userId))) {
+    log.info("Checkout discount refused: not a first-time subscriber", {
+      dodo: { discountRequested: discountCode },
+    });
+    return c.json(
+      {
+        error: "That code is only valid on a first subscription.",
+        code: "discount_not_eligible",
+      },
+      409,
+    );
+  }
+
   try {
     const checkout = await client.checkoutSessions.create({
       product_cart: [{ product_id: env.DODO_PRO_PRODUCT_ID, quantity: 1 }],
@@ -120,7 +170,22 @@ billingRoute.post("/checkout", async (c) => {
       // The webhook resolves entitlement from this, so it is not optional --
       // without it a paid subscription can only be matched back by email.
       metadata: { userId },
-      ...(parsed.data.discountCode ? { discount_code: parsed.data.discountCode } : {}),
+      // Two mutually exclusive shapes, and Dodo rejects the pair outright
+      // ("Discount code is not allowed if allow_discount_code is false"):
+      //
+      // - Code forwarded: Dodo renders it pre-applied and *disabled*, so it is
+      //   locked to the one we authorised.
+      // - No code: the hosted page otherwise shows an "Apply discount code" field
+      //   by default (`allow_discount_code` defaults to true), and a returning
+      //   customer typing LAUNCH into it was measured to get the discount. Turning
+      //   the field off is what stops a server-side gate being trivially bypassed
+      //   on Dodo's own page.
+      //
+      // `discount_codes` rather than `discount_code`: the singular field is marked
+      // @deprecated in the SDK, and revenue should not rest on a deprecated field.
+      ...(discountCode
+        ? { discount_codes: [discountCode] }
+        : { feature_flags: { allow_discount_code: false } }),
       // Derived from CORS_ORIGIN rather than its own env var: one more billing
       // variable to forget at deploy time, for a value we already know.
       return_url: `${appOrigin()}/dashboard?checkout=success`,
@@ -134,11 +199,23 @@ billingRoute.post("/checkout", async (c) => {
     }
 
     log.info("Dodo checkout session created", {
-      dodo: { sessionId: checkout.session_id, discountCode: parsed.data.discountCode ?? null },
+      dodo: {
+        sessionId: checkout.session_id,
+        // Both, so a refused redemption is visible rather than looking like the
+        // user never asked for one.
+        discountCode: discountCode ?? null,
+        discountRequested: parsed.data.discountCode ?? null,
+      },
     });
     return c.json({ checkoutUrl: checkout.checkout_url });
   } catch (error) {
-    log.error("Dodo checkout session failed", { error });
+    // Error first, context second -- see routes/webhooks/dodo.ts. The inverted
+    // shape drops the reason, and "why did checkout fail" is the whole question
+    // here: an invalid discount code, a rejected product id and a Dodo outage all
+    // reach this line and want different responses.
+    log.error(error instanceof Error ? error : String(error), {
+      dodo: { stage: "checkout-session" },
+    });
     return c.json({ error: "Could not start checkout." }, 502);
   }
 });
@@ -167,7 +244,9 @@ billingRoute.post("/portal", async (c) => {
     });
     return c.json({ portalUrl: portal.link });
   } catch (error) {
-    log.error("Dodo customer portal failed", { error });
+    log.error(error instanceof Error ? error : String(error), {
+      dodo: { stage: "customer-portal" },
+    });
     return c.json({ error: "Could not open the billing portal." }, 502);
   }
 });
@@ -207,6 +286,22 @@ billingRoute.post("/reconcile", async (c) => {
   if (!client) return c.json({ error: "Billing is not configured." }, 404);
 
   const userId = c.get("userId");
+
+  // Every call below spends an outbound Dodo API request on an id the caller
+  // chose, so without a cap an authenticated user can walk subscription ids at
+  // our expense. Ids are long and random enough that a hit is implausible -- the
+  // cost is unmetered egress and Dodo rate-limit pressure, not exposure. The
+  // per-plan burst bucket already exists and is the right size for a call a real
+  // user makes once per checkout, so this reuses it rather than adding a second
+  // limiter with its own semantics.
+  try {
+    await enforceAiBurst(c, "billing-reconcile", userId);
+  } catch (error) {
+    const response = quotaErrorResponse(c, error);
+    if (response) return response;
+    throw error;
+  }
+
   const parsed = reconcileSchema.safeParse(await c.req.json().catch(() => null));
   if (!parsed.success) return c.json({ error: "Invalid request" }, 400);
   const { subscriptionId } = parsed.data;
@@ -217,9 +312,15 @@ billingRoute.post("/reconcile", async (c) => {
   } catch (error) {
     // A forged or stale id lands here. Nothing is written and nothing is leaked
     // about whether the id exists.
+    // Stays a `warn` with the reason flattened to a string, rather than
+    // `log.error(error, ...)`: a forged or stale id is the expected way into this
+    // branch, and escalating it to `error` would page on every one of them. The
+    // string keeps the cause readable without the raw Error serialising to `{}`.
     log.warn("Post-checkout reconcile could not load the subscription", {
-      dodo: { subscriptionId },
-      error,
+      dodo: {
+        subscriptionId,
+        reason: error instanceof Error ? error.message : String(error),
+      },
     });
     return c.json({ error: "Could not confirm the subscription." }, 404);
   }
@@ -268,7 +369,9 @@ billingRoute.post("/reconcile", async (c) => {
     // `DODO_PRO_PRODUCT_ID` -- our fault, not the caller's. Without this the throw
     // reaches Hono's global handler with no billing-level log, and every reconcile
     // 500s with nothing saying why.
-    log.error("Post-checkout reconcile failed", { dodo: { subscriptionId }, error });
+    log.error(error instanceof Error ? error : String(error), {
+      dodo: { stage: "reconcile", subscriptionId },
+    });
     return c.json({ error: "Could not confirm the subscription." }, 502);
   }
   if (skipped) {

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -198,14 +198,11 @@ billingRoute.post("/checkout", async (c) => {
       return c.json({ error: "Could not start checkout." }, 502);
     }
 
+    // Only the applied code. A refusal cannot reach this line -- it returned 409
+    // above -- and logs its own line there, so a second "requested" field here
+    // would always be identical to this one.
     log.info("Dodo checkout session created", {
-      dodo: {
-        sessionId: checkout.session_id,
-        // Both, so a refused redemption is visible rather than looking like the
-        // user never asked for one.
-        discountCode: discountCode ?? null,
-        discountRequested: parsed.data.discountCode ?? null,
-      },
+      dodo: { sessionId: checkout.session_id, discountCode: discountCode ?? null },
     });
     return c.json({ checkoutUrl: checkout.checkout_url });
   } catch (error) {

--- a/apps/server/src/routes/webhooks/dodo.ts
+++ b/apps/server/src/routes/webhooks/dodo.ts
@@ -25,7 +25,7 @@ import type { AuditableLogger } from "evlog";
 import type { EvlogVariables } from "evlog/hono";
 import { Hono } from "hono";
 import { dodoClient } from "../../lib/dodo";
-import { clawback, upsertSubscription } from "../../lib/dodo/subscription-sync";
+import { clawback, clawbackForDispute, upsertSubscription } from "../../lib/dodo/subscription-sync";
 
 export const dodoWebhookRoute = new Hono<EvlogVariables>();
 
@@ -50,8 +50,18 @@ dodoWebhookRoute.post("/", async (c) => {
     // Alert on this. A 401 here means paid users silently never get upgraded:
     // the most likely cause is a test-mode secret left in place after the switch
     // to live, and nothing else in the system would surface it.
-    log.error("Dodo webhook signature verification failed", {
-      error,
+    //
+    // The Error goes in as the FIRST argument, which is evlog's documented shape
+    // (`log.error(err, { context })`) and the only one that keeps the reason:
+    // it lands as `error.message` with the context merged alongside. Passing a
+    // string first and `{ error }` as context -- which reads more naturally and is
+    // what this used to do -- overwrites the error context with a raw Error, and
+    // an Error JSON-serialises to `{}`. Measured on this exact endpoint: that
+    // shape emitted `"error":{}` with no message at all, so the Sentry alert this
+    // line exists to feed would have said only "401 on /api/webhooks/dodo".
+    // Telling "wrong secret" from "timestamp outside tolerance" is the entire
+    // value of that alert, especially in the hours after the live-mode switch.
+    log.error(error instanceof Error ? error : String(error), {
       dodo: { webhookId: headers["webhook-id"] },
     });
     return c.json({ error: "Invalid signature" }, 401);
@@ -92,12 +102,11 @@ dodoWebhookRoute.post("/", async (c) => {
     // the subscription upsert is idempotent and guarded on `lastEventAt`.
     skipped = await handleEvent(event, log);
   } catch (error) {
-    // Read the cause out BEFORE logging. evlog rewrites the message of an Error
-    // passed as a field to the log's own message, so reading it afterwards stores
-    // "Dodo webhook handler failed" for every failure and loses the one detail
-    // this column exists to keep.
+    // Read the cause out BEFORE logging. evlog rewrites the message of the Error
+    // it captures, so reading it afterwards stores the log's own wording and
+    // loses the one detail this column exists to keep.
     const reason = error instanceof Error ? error.message : String(error);
-    log.error("Dodo webhook handler failed", { error });
+    log.error(error instanceof Error ? error : String(error), { dodo: { stage: "handler" } });
     // Kept, with the reason, so a stuck event is greppable. `processedAt` stays
     // null, so Dodo's retry will run the handler again rather than short-circuit.
     await db.update(webhookEvent).set({ error: reason }).where(eq(webhookEvent.id, webhookId));
@@ -138,6 +147,9 @@ async function handleEvent(
     case "subscription.failed":
     case "subscription.cancelled":
     case "subscription.expired":
+    // Carries a full Subscription like the rest, so it costs nothing to keep the
+    // row in sync rather than discarding the payload.
+    case "subscription.update_payment_method":
       return await upsertSubscription(event.data, eventAt, log);
 
     // Log-only, for reconciling our ledger against Dodo payouts. Entitlement
@@ -154,6 +166,21 @@ async function handleEvent(
     // period end the way a cancellation does.
     case "refund.succeeded":
       return await clawback(event.data, eventAt, log);
+
+    // A chargeback is a refund we did not choose, and **no `refund.*` event fires
+    // for one** -- so without these two the clawback above never runs and someone
+    // who disputed the charge keeps Pro until the period ends. `dispute.lost` is
+    // the network deciding for the cardholder; `dispute.accepted` is us not
+    // contesting. Dodo's docs are explicit that both mean the funds are gone and
+    // access should stay revoked, and RDR auto-resolutions arrive as `dispute.lost`.
+    //
+    // Deliberately NOT acting on `dispute.opened`: the money is only held at that
+    // point, and a dispute we go on to win would have to be un-revoked, which is a
+    // restore path with no natural trigger. Waiting for the terminal event keeps
+    // this one-directional.
+    case "dispute.lost":
+    case "dispute.accepted":
+      return await clawbackForDispute(event.data, eventAt, log);
 
     default:
       log.info("Unhandled Dodo webhook event");

--- a/apps/web/src/components/billing/checkout-return.tsx
+++ b/apps/web/src/components/billing/checkout-return.tsx
@@ -24,6 +24,32 @@ import { reconcileCheckout } from "@/lib/billing-client";
  */
 const TERMINAL_STATUSES = new Set(["failed", "expired", "cancelled"]);
 
+/**
+ * The message for a terminal status, which is not one message.
+ *
+ * Only `failed` licenses the claim that no money moved: per Dodo it means the
+ * mandate could not be created at all. `cancelled` is the opposite -- it means
+ * paid, then cancelled -- and `expired` says nothing either way about the
+ * original charge, so telling either of them "no charge was made" would be
+ * asserting something we do not know and, for `cancelled`, something false.
+ *
+ * They all stay terminal, though. Letting `cancelled` fall through to "your
+ * upgrade is being confirmed" would leave someone waiting for an upgrade that is
+ * never coming, which is the failure this whole branch exists to prevent.
+ */
+function terminalToast(status: string): { title: string; description: string } {
+  if (status === "failed") {
+    return {
+      title: "That payment didn't go through.",
+      description: "No charge was made. You can try again with another payment method.",
+    };
+  }
+  return {
+    title: "This subscription isn't active.",
+    description: "Check your billing settings, or start a new subscription.",
+  };
+}
+
 export function CheckoutReturn() {
   const router = useRouter();
   const params = useSearchParams();
@@ -66,13 +92,10 @@ export function CheckoutReturn() {
         if (planId === "pro") {
           toast.success("You're on Pro.", { description: "Your credits have been topped up." });
         } else if (TERMINAL_STATUSES.has(status)) {
-          // Nothing is coming. Dodo's `failed` means the mandate could not be
-          // created at all, and it is not recoverable -- the customer has to start
-          // a new subscription. Saying "confirming shortly" here leaves someone
-          // waiting for an upgrade that will never arrive.
-          toast.error("That payment didn't go through.", {
-            description: "No charge was made. You can try again with another payment method.",
-          });
+          // Nothing is coming, so say so. Saying "confirming shortly" here leaves
+          // someone waiting for an upgrade that will never arrive.
+          const { title, description } = terminalToast(status);
+          toast.error(title, { description });
         } else {
           // Still `pending` at Dodo. This one really is a wait -- the webhook
           // finishes it.
@@ -89,9 +112,8 @@ export function CheckoutReturn() {
         // over the top of it -- the same wrong-way-round message §4 of HANDOVER2
         // fixed on the success path, just reached through the error path instead.
         if (urlStatus && TERMINAL_STATUSES.has(urlStatus)) {
-          toast.error("That payment didn't go through.", {
-            description: "No charge was made. You can try again with another payment method.",
-          });
+          const { title, description } = terminalToast(urlStatus);
+          toast.error(title, { description });
           return;
         }
         // Otherwise never claim failure: the money may well have been taken and

--- a/apps/web/src/components/billing/checkout-return.tsx
+++ b/apps/web/src/components/billing/checkout-return.tsx
@@ -28,6 +28,11 @@ export function CheckoutReturn() {
   const router = useRouter();
   const params = useSearchParams();
   const subscriptionId = params.get("subscription_id");
+  // Dodo appends this alongside `subscription_id`, e.g.
+  // `?checkout=success&subscription_id=sub_...&status=failed`. It is forgeable, so
+  // it is only ever used to make a message *more* pessimistic -- never to grant
+  // anything, and never to override what the server actually returned.
+  const urlStatus = params.get("status");
   const isCheckoutReturn = params.get("checkout") === "success" || Boolean(subscriptionId);
   // React strict mode mounts effects twice in dev, and the reconcile is a POST.
   // It is idempotent server-side, but firing it twice would double the toast.
@@ -78,8 +83,19 @@ export function CheckoutReturn() {
       })
       .catch(() => {
         if (!live) return;
-        // Never claim failure: the money may well have been taken and the webhook
-        // may still land. Point at the page that reads the real state.
+        // The reconcile did not answer, so fall back to what Dodo put in the URL.
+        // Measured 2026-07-28: a declined mandate returns here as
+        // `...&status=failed`, and this branch used to announce "Payment received"
+        // over the top of it -- the same wrong-way-round message §4 of HANDOVER2
+        // fixed on the success path, just reached through the error path instead.
+        if (urlStatus && TERMINAL_STATUSES.has(urlStatus)) {
+          toast.error("That payment didn't go through.", {
+            description: "No charge was made. You can try again with another payment method.",
+          });
+          return;
+        }
+        // Otherwise never claim failure: the money may well have been taken and
+        // the webhook may still land. Point at the page that reads the real state.
         toast.info("Payment received.", {
           description: "Your upgrade is being confirmed and will appear shortly.",
         });
@@ -102,7 +118,7 @@ export function CheckoutReturn() {
       // once; the reconcile is idempotent either way.
       handled.current = false;
     };
-  }, [isCheckoutReturn, subscriptionId, router]);
+  }, [isCheckoutReturn, subscriptionId, urlStatus, router]);
 
   return null;
 }


### PR DESCRIPTION
Test-mode hardening pass before the live-mode switch. Everything here was
measured against the real Dodo test API or a real browser, not reasoned about.

## Money holes closed

- **The LAUNCH discount was redeemable by anyone, forever.** With `customer_eligibility: "first_time"` *and* `per_customer_usage_limit: 1` both  set, a customer with an active subscription and three prior redemptions still got 37.5% off - both pre-applied and by typing the code into Dodo's own page. Neither restriction binds. Now gated server-side, plus `allow_discount_code: false` when we aren't forwarding a code (it defaults to  true, which is how the hosted-page bypass worked).
- **Chargebacks granted free Pro.** A dispute fires no `refund.*` event, so the clawback never ran. `dispute.lost` / `dispute.accepted` now revoke.
- **Instalment refunds escaped clawback.** `refund.is_partial` describes one  refund, so a sale refunded in two parts was never `false` on either.
- **`subscription.status` was an unchecked cast** with no CHECK constraint  behind it, so a new Dodo status would silently de-entitle a paying customer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens billing before live mode by enforcing first‑time discount eligibility, revoking access on chargebacks/full refunds, validating subscription statuses, and correcting post‑checkout messaging. Also improves logging/redaction and rate‑limits reconcile to prevent abuse.

- **Bug Fixes**
  - Gate promo codes server-side: only users with no non‑`failed` subscriptions may redeem; forward `discount_codes` or disable the field via `feature_flags.allow_discount_code: false`; return 409 `discount_not_eligible`.
  - Revoke access on chargebacks and full refunds: handle `dispute.lost`/`dispute.accepted`; treat payments as fully refunded when `payment.refund_status === "full"` or `refund.is_partial === false`.
  - Validate `subscription.status` against `subscriptionStatuses` during upsert; throw on unknown; handle `subscription.update_payment_method`.
  - Fix checkout return: read `status` and show terminal messages for `failed`/`expired`/`cancelled`; only `failed` claims “no charge”.
  - Rate‑limit `POST /billing/reconcile`; improve logs by passing the Error as the first arg to `evlog` and setting `redact: true`.

- **Refactors**
  - Use `setWhere` for `onConflictDoUpdate` guards in subscription upserts and quota counters to keep ordering/credit guards explicit and future‑proof.

<sup>Written for commit 9eda8ccb7d5995044c47f7f23620657c3452f962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

