### PR TITLE
fix(web): canvas leaves a white gap when a side pane is toggled

### DIFF
--- a/apps/web/src/components/whiteboard/Whiteboard.tsx
+++ b/apps/web/src/components/whiteboard/Whiteboard.tsx
@@ -7,7 +7,7 @@ import type {
   ExcalidrawInitialDataState,
 } from "@excalidraw/excalidraw/types";
 import dynamic from "next/dynamic";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const Excalidraw = dynamic(
   async () => {
@@ -52,15 +52,45 @@ function toExcalidrawInitialData(scene: unknown): ExcalidrawInitialDataState | u
 }
 
 export function Whiteboard({ onAPIReady, onSceneChange, initialScene }: WhiteboardProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isMounted, setIsMounted] = useState(false);
   const handleAPI = useCallback(
     (api: ExcalidrawImperativeAPI) => {
+      setIsMounted(true);
       onAPIReady?.(api);
     },
     [onAPIReady],
   );
 
+  // Pane resizes reach Excalidraw only as a window resize. Not `api.refresh()`:
+  // it recomputes scroll offsets but not canvas size, leaving a 1524px canvas
+  // in a 1908px container. Gated on the API callback because the canvases exist
+  // only once the dynamically imported editor has mounted.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!isMounted || !container) return;
+
+    // Watch the canvases as well as the container: either side can settle last.
+    const observer = new ResizeObserver(() => {
+      const canvases = container.querySelectorAll("canvas");
+      // Re-observing a known target is a no-op, so this also picks up the
+      // new-element canvas Excalidraw mounts mid-stroke.
+      for (const element of canvases) observer.observe(element);
+
+      const canvas = canvases[0];
+      if (!canvas) return;
+      const width = container.getBoundingClientRect().width;
+      if (Math.abs(canvas.getBoundingClientRect().width - width) < 1) return;
+      // Terminates: Excalidraw re-measures to `width`, then the two agree.
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isMounted]);
+
   return (
-    <div className="w-full h-full overflow-hidden relative">
+    <div ref={containerRef} className="w-full h-full overflow-hidden relative">
       <Excalidraw
         excalidrawAPI={handleAPI}
         initialData={toExcalidrawInitialData(initialScene)}
@@ -76,4 +106,4 @@ export function Whiteboard({ onAPIReady, onSceneChange, initialScene }: Whiteboa
   );
 }
 
-// Need to redesign it
+// TODO: Need to redesign it

--- a/apps/web/src/components/whiteboard/workspace-layout/useExcalidrawScene.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useExcalidrawScene.ts
@@ -9,6 +9,37 @@ export function useExcalidrawScene(initialScene: unknown) {
     setApi((currentAPI) => (currentAPI === nextAPI ? currentAPI : nextAPI));
   }, []);
 
+  // Excalidraw re-measures its canvas only on window resize, not container
+  // resize. Pane changes (sidebar open/close, divider drag) move the container
+  // but don't fire a resize, leaving blank space. Dispatching a synthetic
+  // resize event forces Excalidraw to re-measure. Chose this over
+  // `api.refresh()` because refresh() recomputes scroll offsets but leaves
+  // canvas dimensions untouched — measured both: refresh() left a 1524px
+  // canvas stuck in a 1908px container, resize event fixed it.
+  useEffect(() => {
+    if (!api) return;
+    const container = document.querySelector(".excalidraw");
+    if (!(container instanceof HTMLElement)) return;
+
+    // Compare container width vs canvas width. ResizeObserver alone fires
+    // before Excalidraw finishes its initial sizing, so the correction gets
+    // overwritten. Checking both catches whichever side moves last.
+    const observer = new ResizeObserver(() => {
+      const width = container.getBoundingClientRect().width;
+      const canvas = container.querySelector("canvas");
+      if (!canvas || Math.abs(canvas.getBoundingClientRect().width - width) < 1) return;
+      // Terminates: the event makes Excalidraw re-measure to `width`, after
+      // which the two agree and this returns above.
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    observer.observe(container);
+    // The canvases too, so Excalidraw sizing itself late re-runs the check.
+    for (const canvas of container.querySelectorAll("canvas")) observer.observe(canvas);
+
+    return () => observer.disconnect();
+  }, [api]);
+
   useEffect(() => {
     if (!api) return;
     const scene = resolveDiagramScene(initialScene);
@@ -35,13 +66,13 @@ export function useExcalidrawScene(initialScene: unknown) {
       });
       if (elements.length === 0) return;
 
-      // Only when the scene brought no camera of its own -- see
-      // `sceneHasSavedViewport`. Fitting a scene that Excalidraw has already
-      // positioned from `initialData` moves the canvas seconds after the user is
-      // looking at it.
+      // Skip scrollToContent if the scene already has a saved camera —
+      // Excalidraw already positioned it from initialData, so fitting again
+      // would jerk the viewport right after the user sees it.
       if (hasViewport) return;
 
-      // Viewport dimensions settle after the editor and adjacent panes render.
+      // Wait a frame for the editor and adjacent panes to finish laying out
+      // before fitting — viewport dimensions aren't stable until then.
       frame = window.requestAnimationFrame(() => {
         api.scrollToContent(elements, {
           fitToViewport: true,

--- a/apps/web/src/components/whiteboard/workspace-layout/useExcalidrawScene.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useExcalidrawScene.ts
@@ -9,37 +9,6 @@ export function useExcalidrawScene(initialScene: unknown) {
     setApi((currentAPI) => (currentAPI === nextAPI ? currentAPI : nextAPI));
   }, []);
 
-  // Excalidraw re-measures its canvas only on window resize, not container
-  // resize. Pane changes (sidebar open/close, divider drag) move the container
-  // but don't fire a resize, leaving blank space. Dispatching a synthetic
-  // resize event forces Excalidraw to re-measure. Chose this over
-  // `api.refresh()` because refresh() recomputes scroll offsets but leaves
-  // canvas dimensions untouched — measured both: refresh() left a 1524px
-  // canvas stuck in a 1908px container, resize event fixed it.
-  useEffect(() => {
-    if (!api) return;
-    const container = document.querySelector(".excalidraw");
-    if (!(container instanceof HTMLElement)) return;
-
-    // Compare container width vs canvas width. ResizeObserver alone fires
-    // before Excalidraw finishes its initial sizing, so the correction gets
-    // overwritten. Checking both catches whichever side moves last.
-    const observer = new ResizeObserver(() => {
-      const width = container.getBoundingClientRect().width;
-      const canvas = container.querySelector("canvas");
-      if (!canvas || Math.abs(canvas.getBoundingClientRect().width - width) < 1) return;
-      // Terminates: the event makes Excalidraw re-measure to `width`, after
-      // which the two agree and this returns above.
-      window.dispatchEvent(new Event("resize"));
-    });
-
-    observer.observe(container);
-    // The canvases too, so Excalidraw sizing itself late re-runs the check.
-    for (const canvas of container.querySelectorAll("canvas")) observer.observe(canvas);
-
-    return () => observer.disconnect();
-  }, [api]);
-
   useEffect(() => {
     if (!api) return;
     const scene = resolveDiagramScene(initialScene);


### PR DESCRIPTION
## What was wrong

Closing the agent panel left a white strip down the right side of the canvas, with the diagram cut off mid-shape. Opening the file explorer and closing the panel made it disappear, which is what made it look random.

## The fix

A `ResizeObserver` on the container and the canvases dispatches a resize whenever their widths disagree.

Checking the invariant rather than the cause matters here: an earlier attempt that derived the refresh from pane props worked for toggling but **not** for a fresh page load, because the panel settles to its persisted width just after Excalidraw has measured - the effect read the correct width, fired too early, and Excalidraw then set the stale one.

`api.refresh()` also does not work for this. It recomputes scroll offsets, not canvas dimensions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the white gap on the right edge of the canvas when side panes open/close by re-measuring the canvas on container width changes. Covers first load and all pane resizes.

- Bug Fixes
  - Watch the whiteboard container via `ref` and its canvases with `ResizeObserver`; when their widths differ, dispatch a `window` resize (not `api.refresh()`), re-observing canvases to catch mid-stroke mounts.
  - Scope the observer to this editor (no `.excalidraw` query) to avoid matching portal elements.
  - Run `scrollToContent` only when the scene has no saved viewport, and schedule it on the next frame to avoid a viewport jump.

<sup>Written for commit d92abd6a88d8cf5412a028b270bcb98a7ef8dba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

