### PR TITLE
fix(server): stop reporting user input as billing failures

### DIFF
--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -12,6 +12,7 @@ import { and, db, eq, inArray, ne, sql } from "@OpenDiagram/db";
 import { user } from "@OpenDiagram/db/schema/auth";
 import { ENTITLING_SUBSCRIPTION_STATUSES, subscription } from "@OpenDiagram/db/schema/billing";
 import { env } from "@OpenDiagram/env/server";
+import { NotFoundError } from "dodopayments";
 import { Hono } from "hono";
 import { z } from "zod";
 import { appOrigin, billingEnabled, dodoClient } from "../lib/dodo";
@@ -206,10 +207,18 @@ billingRoute.post("/checkout", async (c) => {
     });
     return c.json({ checkoutUrl: checkout.checkout_url });
   } catch (error) {
-    // Error first, context second -- see routes/webhooks/dodo.ts. The inverted
-    // shape drops the reason, and "why did checkout fail" is the whole question
-    // here: an invalid discount code, a rejected product id and a Dodo outage all
-    // reach this line and want different responses.
+    // Discount typos are user error, not a 502. Dodo returns
+    // `404 Discount code 'X' doesn't exist` -- matched on the message, not 404
+    // alone, because a wrong DODO_PRO_PRODUCT_ID also 404s and should stay loud.
+    if (discountCode && error instanceof NotFoundError && /discount code/i.test(error.message)) {
+      log.info("Checkout discount rejected by Dodo", {
+        dodo: { discountRequested: discountCode },
+      });
+      return c.json({ error: "That code isn't valid.", code: "invalid_discount" }, 400);
+    }
+    // Error first, not string+{error}: see routes/webhooks/dodo.ts for why.
+    // A wrong product id and a Dodo outage both land here -- the log.context
+    // tells which.
     log.error(error instanceof Error ? error : String(error), {
       dodo: { stage: "checkout-session" },
     });

--- a/apps/server/src/routes/webhooks/dodo.ts
+++ b/apps/server/src/routes/webhooks/dodo.ts
@@ -50,12 +50,18 @@ dodoWebhookRoute.post("/", async (c) => {
     // Error first, not string+{error}: an Error JSON-serialises to {}, so the
     // alert would say only "401 on /api/webhooks/dodo" with no reason.
     //
-    // Level splits on signature presence. Signed-and-rejected means a test-mode
-    // secret left in prod: paid users silently not upgraded, nothing else alarms.
-    // No signature is a scanner or curl probe -- warn, not error.
+    // Level splits on whether a signature was actually presented. Signed-and-
+    // rejected means a test-mode secret left in prod: paid users silently not
+    // upgraded, nothing else alarms. Unsigned is a scanner or curl probe.
+    //
+    // All three headers, because that is the gate `unwrap` itself applies: a
+    // missing or empty id/timestamp/signature throws "Missing required headers"
+    // before any byte comparison, so no such request can be a stale secret.
+    const signed =
+      headers["webhook-signature"] && headers["webhook-id"] && headers["webhook-timestamp"];
     const context = { dodo: { webhookId: headers["webhook-id"] } };
     // warn() has no Error overload, so stringify for the probe path.
-    if (headers["webhook-signature"]) {
+    if (signed) {
       log.error(error instanceof Error ? error : String(error), context);
     } else {
       log.warn(String(error), context);

--- a/apps/server/src/routes/webhooks/dodo.ts
+++ b/apps/server/src/routes/webhooks/dodo.ts
@@ -47,23 +47,19 @@ dodoWebhookRoute.post("/", async (c) => {
   try {
     event = client.webhooks.unwrap(raw, { headers });
   } catch (error) {
-    // Alert on this. A 401 here means paid users silently never get upgraded:
-    // the most likely cause is a test-mode secret left in place after the switch
-    // to live, and nothing else in the system would surface it.
+    // Error first, not string+{error}: an Error JSON-serialises to {}, so the
+    // alert would say only "401 on /api/webhooks/dodo" with no reason.
     //
-    // The Error goes in as the FIRST argument, which is evlog's documented shape
-    // (`log.error(err, { context })`) and the only one that keeps the reason:
-    // it lands as `error.message` with the context merged alongside. Passing a
-    // string first and `{ error }` as context -- which reads more naturally and is
-    // what this used to do -- overwrites the error context with a raw Error, and
-    // an Error JSON-serialises to `{}`. Measured on this exact endpoint: that
-    // shape emitted `"error":{}` with no message at all, so the Sentry alert this
-    // line exists to feed would have said only "401 on /api/webhooks/dodo".
-    // Telling "wrong secret" from "timestamp outside tolerance" is the entire
-    // value of that alert, especially in the hours after the live-mode switch.
-    log.error(error instanceof Error ? error : String(error), {
-      dodo: { webhookId: headers["webhook-id"] },
-    });
+    // Level splits on signature presence. Signed-and-rejected means a test-mode
+    // secret left in prod: paid users silently not upgraded, nothing else alarms.
+    // No signature is a scanner or curl probe -- warn, not error.
+    const context = { dodo: { webhookId: headers["webhook-id"] } };
+    // warn() has no Error overload, so stringify for the probe path.
+    if (headers["webhook-signature"]) {
+      log.error(error instanceof Error ? error : String(error), context);
+    } else {
+      log.warn(String(error), context);
+    }
     return c.json({ error: "Invalid signature" }, 401);
   }
 


### PR DESCRIPTION
Two errors in production Sentry on 2026-08-05, neither a real fault.

**Bad discount code returned 502.** A code that does not exist hit the generic Dodo catch-all in `POST /api/billing/checkout` and came back as `502 Could not start checkout.` plus a `log.error`. Dodo answers it with `404 Discount code 'X' doesn't exist`, so a buyer's typo told them the site was broken and paged us for their spelling. Now `400 invalid_discount` with a `log.info`. Matched on the message rather than on 404 alone: a wrong `DODO_PRO_PRODUCT_ID` also 404s from this call, and that one has to stay loud.

**Unsigned webhook probes logged at error.** `POST /api/webhooks/dodo` logged every 401 at error, including requests carrying no signature at all. Those are probes, either a scanner on a public URL or the paymentguide.md §4 deploy check. The level now splits on `webhook-signature` presence, so the alert that exists to catch a stale signing secret is not diluted by traffic that never presented one.

No web change: `billing-client.ts` already surfaces the server's `error` string.

<img width="458" height="144" alt="image" src="https://github.com/user-attachments/assets/64f50eab-0d0e-40ba-bd2d-9bbc37bc46d6" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop paging on normal user input in billing. Invalid discount codes now return 400 with a clear error, and webhook signature failures only alert when all signature headers are present.

- **Bug Fixes**
  - Checkout: detect `404 Discount code 'X' doesn't exist` from `dodopayments` and return `400 { code: "invalid_discount" }` with info-level log; match on message so wrong product ID 404s still error.
  - Webhooks: gate log level on presence of `webhook-id`, `webhook-timestamp`, and `webhook-signature`; signed-but-rejected stays error to catch stale secrets, missing any header logs warn; both return 401.

<sup>Written for commit 35504044931caf9c863740894da6e04a343ba8f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

