### PR TITLE
fix(server): preload Sentry so database queries get traced

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -26,4 +26,5 @@ ENV SKIP_ENV_VALIDATION=
 EXPOSE 3000
 
 WORKDIR /app/apps/server
-CMD ["bun", "run", "dist/index.mjs"]
+# --preload is load-bearing for db tracing. See the Sentry note in src/index.ts.
+CMD ["bun", "run", "--preload", "@sentry/node/preload", "dist/index.mjs"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,9 +5,8 @@
   "scripts": {
     "build": "tsdown",
     "check-types": "tsgo --noEmit",
-    "compile": "bun build --compile --minify --sourcemap --bytecode ./src/index.ts --outfile server",
-    "dev": "bun --hot src/index.ts",
-    "start": "bun run dist/index.mjs"
+    "dev": "bun --hot --preload @sentry/node/preload src/index.ts",
+    "start": "bun run --preload @sentry/node/preload dist/index.mjs"
   },
   "dependencies": {
     "@OpenDiagram/auth": "workspace:*",
@@ -21,6 +20,7 @@
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@sentry/bun": "10.68.0",
     "@sentry/hono": "10.68.0",
+    "@sentry/node": "10.68.0",
     "ai": "catalog:",
     "better-auth": "catalog:",
     "dodopayments": "^2.43.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -38,7 +38,11 @@ const SENTRY_DSN =
 
 const app = new Hono<{ Variables: SessionVariables }>();
 
-// Sentry middleware must run as early as possible; it initializes the SDK.
+// The middleware is the SDK's only init, and it runs after the imports above have
+// already pulled in `pg` (@OpenDiagram/auth -> @OpenDiagram/db) -- too late to
+// instrument it. `@sentry/node/preload` wraps modules first, so the run scripts
+// and the Dockerfile pass `--preload`; without that flag every `db` span vanishes.
+// https://docs.sentry.io/platforms/javascript/guides/hono/install/late-initialization/
 app.use(
   sentry(app, {
     dsn: SENTRY_DSN,

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@sentry/bun": "10.68.0",
         "@sentry/hono": "10.68.0",
+        "@sentry/node": "10.68.0",
         "ai": "catalog:",
         "better-auth": "catalog:",
         "dodopayments": "^2.43.0",


### PR DESCRIPTION
Production has never emitted a single `db` span. Every Postgres query the API runs has been invisible in Sentry since the project started, while `http.server`, `middleware.hono` and `gen_ai` spans arrived normally, which is why nothing looked broken.

**Cause:** the `sentry()` Hono middleware is the SDK's only init, and it runs from the module body. By then the imports at the top of `index.ts` have already loaded `pg` through `@OpenDiagram/auth -> @OpenDiagram/db`, so OpenTelemetry never wrapped the driver. Initialization order, not configuration.

**Fix:** `@sentry/node/preload` wraps the modules before the app graph loads. The middleware keeps initializing exactly where it does and remains the only init, so route naming, request data and error capture are untouched. This is Sentry's documented Late Initialization pattern for Hono.

Also drops the unused `compile` script: nothing referenced it, and Sentry's auto instrumentation does not work in compiled output, so deploying that binary would silently reintroduce this bug.


## Notes

- `--preload` is load-bearing. Remove the flag from the dev script, the start script or the Dockerfile and `db` spans silently vanish again. Commented at  the call site.
- `@sentry/bun` and `@sentry/node` are both optional peers of `@sentry/hono`,  so the explicit dependency is required.
- Auth queries will show as `[Filtered]` in Sentry because the SQL mentions a password column and the default scrubber redacts it. Unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads Sentry at process start so Postgres queries get auto-instrumented and `db` spans appear in Sentry. Adds `--preload @sentry/node/preload` to dev, start, and Docker; removes the unused compile script that would break tracing.

- **Bug Fixes**
  - Instrument `pg` before `@OpenDiagram/auth`/`@OpenDiagram/db` load so `db` spans emit.
  - Keep the `@sentry/hono` middleware as the only init; routes, request data, and errors unchanged.
  - Remove the `compile` script to avoid compiled output that disables auto-instrumentation.

- **Dependencies**
  - Add `@sentry/node@10.68.0` (optional peer of `@sentry/hono`).

<sup>Written for commit 0eb2ec3b5e6c6d72608873d60e8a01d215deb411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

