### PR TITLE
feat(web): add Umami analytics behind a same-origin proxy

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,6 +16,19 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      // Serve the Umami tracker and its collector from our own origin. Blocklists
+      // match on the `cloud.umami.is` hostname, so the direct snippet loses every
+      // uBlock/Brave visitor. The tracker derives its host from its own src, so
+      // the wildcard has to cover /stats/api/send too, not just /stats/script.js.
+      // https://umami.is/docs/bypass-ad-blockers
+      {
+        source: "/stats/:match*",
+        destination: "https://cloud.umami.is/:match*",
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,19 +16,6 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  async rewrites() {
-    return [
-      // Serve the Umami tracker and its collector from our own origin. Blocklists
-      // match on the `cloud.umami.is` hostname, so the direct snippet loses every
-      // uBlock/Brave visitor. The tracker derives its host from its own src, so
-      // the wildcard has to cover /stats/api/send too, not just /stats/script.js.
-      // https://umami.is/docs/bypass-ad-blockers
-      {
-        source: "/stats/:match*",
-        destination: "https://cloud.umami.is/:match*",
-      },
-    ];
-  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -81,12 +81,12 @@ export default function RootLayout({
         <Toaster position="bottom-right" richColors />
         {/* TODO: delete both (and uninstall @vercel/analytics + @vercel/speed-insights)
             when we move to TanStack Start on Cloudflare. Umami below is the keeper.
-            That move also has to re-create the /stats rewrite in next.config.ts as a
-            Cloudflare route, or the tracker 404s. Same for Sentry's tunnelRoute. */}
+            That move also has to port app/stats/[...path]/route.ts, or the tracker
+            404s. Same for Sentry's tunnelRoute. */}
         <Analytics />
         <SpeedInsights />
-        {/* Proxied through /stats by the next.config rewrite. The tracker hooks
-            pushState itself, so App Router navigations need no extra wiring. */}
+        {/* Proxied by app/stats/[...path]/route.ts. The tracker hooks pushState
+            itself, so App Router navigations need no extra wiring. */}
         {env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
           <Script src="/stats/script.js" data-website-id={env.NEXT_PUBLIC_UMAMI_WEBSITE_ID} />
         )}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter, Instrument_Serif } from "next/font/google";
 import localFont from "next/font/local";
+import Script from "next/script";
+import { env } from "@OpenDiagram/env/web";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "sonner";
@@ -77,8 +79,17 @@ export default function RootLayout({
         {/* sonner renders nothing without this. It was never mounted, so every
             existing `toast.*` call in the dashboard was silently a no-op. */}
         <Toaster position="bottom-right" richColors />
+        {/* TODO: delete both (and uninstall @vercel/analytics + @vercel/speed-insights)
+            when we move to TanStack Start on Cloudflare. Umami below is the keeper.
+            That move also has to re-create the /stats rewrite in next.config.ts as a
+            Cloudflare route, or the tracker 404s. Same for Sentry's tunnelRoute. */}
         <Analytics />
         <SpeedInsights />
+        {/* Proxied through /stats by the next.config rewrite. The tracker hooks
+            pushState itself, so App Router navigations need no extra wiring. */}
+        {env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
+          <Script src="/stats/script.js" data-website-id={env.NEXT_PUBLIC_UMAMI_WEBSITE_ID} />
+        )}
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -85,10 +85,18 @@ export default function RootLayout({
             404s. Same for Sentry's tunnelRoute. */}
         <Analytics />
         <SpeedInsights />
-        {/* Proxied by app/stats/[...path]/route.ts. The tracker hooks pushState
-            itself, so App Router navigations need no extra wiring. */}
+        {/* Proxied by app/stats/[...path]/route.ts. `data-host-url` is required,
+            not cosmetic: the Cloud build of the tracker hardcodes
+            `https://gateway.umami.is` as its collector rather than deriving one
+            from its own src, so without this the beacons skip our proxy and go
+            straight to a blocked host. The tracker hooks pushState itself, so
+            App Router navigations need no extra wiring. */}
         {env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
-          <Script src="/stats/script.js" data-website-id={env.NEXT_PUBLIC_UMAMI_WEBSITE_ID} />
+          <Script
+            src="/stats/script.js"
+            data-website-id={env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+            data-host-url="/stats"
+          />
         )}
       </body>
     </html>

--- a/apps/web/src/app/stats/[...path]/route.ts
+++ b/apps/web/src/app/stats/[...path]/route.ts
@@ -1,0 +1,60 @@
+import type { NextRequest } from "next/server";
+
+const UPSTREAM = "https://cloud.umami.is";
+
+// The tracker fetches exactly these two, both derived from its own script src.
+// Anything else 404s instead of being relayed.
+const ALLOWED: Record<string, "GET" | "POST"> = {
+  "script.js": "GET",
+  "api/send": "POST",
+};
+
+// Everything Umami needs to attribute a hit. Notably absent: `cookie` and
+// `authorization`. A next.config rewrite would have been three lines, but its
+// http-proxy forwards request headers verbatim, and the tracker's POST is
+// same-origin, so the browser attaches our better-auth session cookie and the
+// rewrite hands it to a third party on every pageview of a logged-in user.
+// Verified against Next 16: `cookie` and `authorization` both arrive upstream.
+const FORWARD = ["content-type", "user-agent", "accept-language", "x-forwarded-for"];
+
+async function proxy(req: NextRequest, segments: string[]) {
+  const path = segments.join("/");
+  if (ALLOWED[path] !== req.method) {
+    return new Response(null, { status: 404 });
+  }
+
+  const headers = new Headers();
+  for (const name of FORWARD) {
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+
+  const upstream = await fetch(`${UPSTREAM}/${path}`, {
+    method: req.method,
+    headers,
+    body: req.method === "POST" ? await req.text() : undefined,
+  });
+
+  const response = new Headers();
+  for (const name of ["content-type", "cache-control"]) {
+    const value = upstream.headers.get(name);
+    if (value) response.set(name, value);
+  }
+
+  return new Response(upstream.body, { status: upstream.status, headers: response });
+}
+
+/**
+ * Serves the Umami tracker and its collector from our own origin, because
+ * blocklists match on the `cloud.umami.is` hostname and the snippet Umami
+ * hands you loses every uBlock/Brave visitor.
+ *
+ * https://umami.is/docs/bypass-ad-blockers
+ */
+export async function GET(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  return proxy(req, (await ctx.params).path);
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  return proxy(req, (await ctx.params).path);
+}

--- a/apps/web/src/app/stats/[...path]/route.ts
+++ b/apps/web/src/app/stats/[...path]/route.ts
@@ -1,25 +1,25 @@
 import type { NextRequest } from "next/server";
 
-const UPSTREAM = "https://cloud.umami.is";
-
-// The tracker fetches exactly these two, both derived from its own script src.
-// Anything else 404s instead of being relayed.
-const ALLOWED: Record<string, "GET" | "POST"> = {
-  "script.js": "GET",
-  "api/send": "POST",
+// Two upstreams, not one. The Cloud build of the tracker serves from
+// cloud.umami.is but hardcodes gateway.umami.is as its collector, so beacons go
+// where an unproxied browser would have sent them. Anything not listed here
+// 404s rather than being relayed: a wildcard would let any client bounce
+// arbitrary requests off our domain into Umami's API.
+const ROUTES: Record<string, { method: "GET" | "POST"; upstream: string }> = {
+  "script.js": { method: "GET", upstream: "https://cloud.umami.is/script.js" },
+  "api/send": { method: "POST", upstream: "https://gateway.umami.is/api/send" },
 };
 
 // Everything Umami needs to attribute a hit. Notably absent: `cookie` and
 // `authorization`. A next.config rewrite would have been three lines, but its
-// http-proxy forwards request headers verbatim, and the tracker's POST is
-// same-origin, so the browser attaches our better-auth session cookie and the
-// rewrite hands it to a third party on every pageview of a logged-in user.
-// Verified against Next 16: `cookie` and `authorization` both arrive upstream.
+// http-proxy forwards request headers verbatim (verified against Next 16: both
+// arrive upstream), which hands a live better-auth session cookie to a third
+// party every time a logged-in browser fetches the tracker.
 const FORWARD = ["content-type", "user-agent", "accept-language", "x-forwarded-for"];
 
 async function proxy(req: NextRequest, segments: string[]) {
-  const path = segments.join("/");
-  if (ALLOWED[path] !== req.method) {
+  const route = ROUTES[segments.join("/")];
+  if (route?.method !== req.method) {
     return new Response(null, { status: 404 });
   }
 
@@ -29,10 +29,14 @@ async function proxy(req: NextRequest, segments: string[]) {
     if (value) headers.set(name, value);
   }
 
-  const upstream = await fetch(`${UPSTREAM}/${path}`, {
+  // Bounded so an upstream that hangs costs us one timeout rather than a full
+  // function duration per beacon. A failure here throws and Next answers 500,
+  // which is the honest outcome: analytics is degraded, the page is not.
+  const upstream = await fetch(route.upstream, {
     method: req.method,
     headers,
     body: req.method === "POST" ? await req.text() : undefined,
+    signal: AbortSignal.timeout(5_000),
   });
 
   const response = new Headers();
@@ -46,8 +50,10 @@ async function proxy(req: NextRequest, segments: string[]) {
 
 /**
  * Serves the Umami tracker and its collector from our own origin, because
- * blocklists match on the `cloud.umami.is` hostname and the snippet Umami
- * hands you loses every uBlock/Brave visitor.
+ * blocklists match on the `cloud.umami.is` and `gateway.umami.is` hostnames and
+ * the snippet Umami hands you loses every uBlock/Brave visitor. Pairs with
+ * `data-host-url="/stats"` in the root layout, without which the tracker skips
+ * this route and beacons the blocked host directly.
  *
  * https://umami.is/docs/bypass-ad-blockers
  */

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -8,11 +8,15 @@ export const env = createEnv({
     // Fraction of traces sampled, 0..1. Full sampling by default. The DSN stays
     // hardcoded in apps/web/sentry.dsn.ts.
     NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(1),
+    // Umami Cloud website id. Optional on purpose: unset means the tracker never
+    // renders, so local dev and preview deploys stay out of the production stats.
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
   },
   runtimeEnv: {
     NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
     NEXT_PUBLIC_ASSET_URL: process.env.NEXT_PUBLIC_ASSET_URL,
     NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   emptyStringAsUndefined: true,


### PR DESCRIPTION
Adds Umami Cloud analytics to the web app.

## Why a route handler and not a rewrite

A `next.config.ts` rewrite would be three lines, and it's what Umami's docs suggest. It's also a credential leak here. Next proxies external rewrites with http-proxy, which forwards request headers verbatim (probed on 16.2.11: `cookie` and `authorization` both arrive upstream). The tracker's POST to the collector is same-origin, so the browser attaches our better-auth session cookie, and the rewrite would hand it to cloud.umami.is on every pageview of a logged-in user.

`app/stats/[...path]/route.ts` instead allowlists the only two paths the tracker uses, `script.js` by GET and `api/send` by POST, and forwards an explicit header list that excludes credentials while keeping what Umami needs to attribute a hit. Everything else 404s, so the /stats namespace is not a general relay into Umami's API either.

## Config

`NEXT_PUBLIC_UMAMI_WEBSITE_ID` is optional in `packages/env/src/web.ts`. Unset means no `<Script>` tag renders at all, so local dev and preview deploys never pollute production stats. **Set it on Vercel in the Production scope only.**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Umami Cloud analytics behind a same‑origin proxy to bypass ad‑blockers. The tracker loads from `/stats/script.js` and posts to `/stats/api/send`, and only renders when `NEXT_PUBLIC_UMAMI_WEBSITE_ID` is set.

- **New Features**
  - Serve `/stats/script.js` and `/stats/api/send` via `app/stats/[...path]/route.ts`, allowlisting only these paths: GET → `cloud.umami.is/script.js`, POST → `gateway.umami.is/api/send`; forward minimal headers (no cookies/auth) and bound upstream fetch to 5s.
  - Inject `<Script src="/stats/script.js" data-host-url="/stats" data-website-id="...">` so beacons use the proxy and aren’t blocked.

- **Migration**
  - Set `NEXT_PUBLIC_UMAMI_WEBSITE_ID` in Vercel Production only.

<sup>Written for commit 5e0e7ed438531c7186418047fed27f999a7a8d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



