### PR TITLE
perf: cut canvas save traffic - throttle, element deltas, single-statement write

### DIFF
--- a/apps/server/src/lib/project-file-content.ts
+++ b/apps/server/src/lib/project-file-content.ts
@@ -61,7 +61,7 @@ export async function writeProjectFileContent(
       .select(projectFileContentColumns)
       .from(projectFileContent)
       .where(eq(projectFileContent.fileId, fileId));
-    return existing ?? { scene: null, spec: null, content: null, history: [] };
+    return existing ?? { scene: null, spec: null, content: null, history: [], sceneRev: null };
   }
 
   // Every writer of scene advances scene_rev, not just the PATCH route. Repository

--- a/apps/server/src/lib/project-file-content.ts
+++ b/apps/server/src/lib/project-file-content.ts
@@ -1,10 +1,10 @@
 import { db, eq } from "@OpenDiagram/db";
 import { projectFile, projectFileContent } from "@OpenDiagram/db/schema/projects";
 
-/** Either the pooled `db` or an open transaction -- both satisfy these calls. */
+/** Either the pooled db or an open transaction; both satisfy these calls. */
 type Db = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
 
-/** The large columns, which live in `project_file_content`, not `project_file`. */
+/** The large columns, living in project_file_content, not project_file. */
 export type ProjectFileContentPatch = {
   scene?: unknown;
   spec?: unknown;
@@ -12,48 +12,49 @@ export type ProjectFileContentPatch = {
   history?: unknown[];
 };
 
-/** Selected alongside `project_file` wherever a caller wants the whole file. */
+/** Selected alongside project_file wherever a caller wants the whole file. */
 export const projectFileContentColumns = {
   scene: projectFileContent.scene,
   spec: projectFileContent.spec,
   content: projectFileContent.content,
   history: projectFileContent.history,
+  /** The canvas keeps this to send its next save as a delta. */
+  sceneRev: projectFileContent.sceneRev,
 };
 
 /**
- * Write the content row for a file, creating it if it is not there yet.
+ * Write the content row for a file, creating it if missing.
  *
- * An upsert rather than an insert-then-update pair because every caller is
- * already in the position of not knowing or not caring which case it is in: the
- * create paths know the row is new, the generation and PATCH paths know it
- * should exist, and none of them benefits from finding out. It also means a file
- * whose content row went missing repairs itself on the next write instead of
- * failing forever.
+ * An upsert rather than insert-then-update because every caller already does not
+ * know or care which case it is in: create paths know the row is new, generation
+ * and PATCH paths know it should exist, none benefits from finding out. It also
+ * means a file whose content row went missing repairs itself on the next write
+ * instead of failing forever.
  *
- * Only the columns whose value is not `undefined` are written. That matters for
- * PATCH, where the client sends `scene` alone and must not blank `history` and
- * `spec` as a side effect. The test is on the value rather than key presence
- * (`"scene" in patch`) because an optional Zod field can land in the parsed
- * object as an explicit `undefined`, which key presence would treat as a write.
- * An explicit `null` still clears the column, which is the intended way to do it.
+ * Only columns whose value is not undefined are written. That matters for PATCH,
+ * where the client sends scene alone and must not blank history and spec as a
+ * side effect. The test is on the value rather than key presence ("scene" in
+ * patch) because an optional Zod field can land in the parsed object as explicit
+ * undefined, which key presence would treat as a write. An explicit null still
+ * clears the column, which is the intended way to do it.
  */
 export async function writeProjectFileContent(
   tx: Db,
   fileId: string,
   patch: ProjectFileContentPatch,
-  // `false` for callers that do not read the content back -- the canvas autosave,
-  // the spec write and the chat history write are all fire-and-forget. Skipping
-  // the RETURNING keeps a multi-hundred-kilobyte scene from being detoasted and
-  // shipped to the server only to be serialised out to a client that discards it.
+  // false for callers that do not read the content back: the canvas autosave, the
+  // spec write, and the chat history write are all fire-and-forget. Skipping the
+  // RETURNING keeps a multi-hundred-kilobyte scene from being detoasted and shipped
+  // to the server only to be serialized out to a client that discards it.
   { returnContent = true }: { returnContent?: boolean } = {},
 ) {
   const columns = Object.fromEntries(
     Object.entries(patch).filter(([, value]) => value !== undefined),
   );
 
-  // Nothing to write, and Postgres rejects an empty `DO UPDATE SET`. Reaching
-  // here means the caller had no content fields at all, so the existing row --
-  // or the absence of one -- is already correct.
+  // Nothing to write, and Postgres rejects an empty DO UPDATE SET. Reaching
+  // here means the caller had no content fields at all, so the existing row (or
+  // the absence of one) is already correct.
   if (Object.keys(columns).length === 0) {
     if (!returnContent) return null;
     const [existing] = await tx
@@ -65,7 +66,7 @@ export async function writeProjectFileContent(
 
   const insert = tx
     .insert(projectFileContent)
-    // `history` is NOT NULL with no database default, so the insert half of the
+    // history is NOT NULL with no database default, so the insert half of the
     // upsert has to carry one even when the caller said nothing about history.
     .values({ fileId, history: [], ...columns })
     .onConflictDoUpdate({ target: projectFileContent.fileId, set: columns });
@@ -80,7 +81,7 @@ export async function writeProjectFileContent(
 }
 
 /**
- * Read one file whole -- metadata joined to its content row.
+ * Read one file whole; metadata joined to its content row.
  *
  * Left, not inner: a file is a file even if its content row is missing, and the
  * canvas would rather open empty than 404 on a document the file list just
@@ -98,7 +99,7 @@ export function selectProjectFileColumns() {
   };
 }
 
-/** A file row joined to its content: what `selectProjectFileColumns` produces. */
+/** A file row joined to its content: what selectProjectFileColumns produces. */
 export type ProjectFileWithContent = {
   id: string;
   projectId: string;

--- a/apps/server/src/lib/project-file-content.ts
+++ b/apps/server/src/lib/project-file-content.ts
@@ -1,4 +1,4 @@
-import { db, eq } from "@OpenDiagram/db";
+import { db, eq, sql } from "@OpenDiagram/db";
 import { projectFile, projectFileContent } from "@OpenDiagram/db/schema/projects";
 
 /** Either the pooled db or an open transaction; both satisfy these calls. */
@@ -64,12 +64,23 @@ export async function writeProjectFileContent(
     return existing ?? { scene: null, spec: null, content: null, history: [] };
   }
 
+  // Every writer of scene advances scene_rev, not just the PATCH route. Repository
+  // generation replaces whole scenes through here, and a canvas holding the file
+  // open would otherwise keep a baseline the server had silently moved past and
+  // have its next delta merged into the generated scene instead of rejected.
+  const writesScene = columns.scene !== undefined;
+
   const insert = tx
     .insert(projectFileContent)
     // history is NOT NULL with no database default, so the insert half of the
     // upsert has to carry one even when the caller said nothing about history.
-    .values({ fileId, history: [], ...columns })
-    .onConflictDoUpdate({ target: projectFileContent.fileId, set: columns });
+    .values({ fileId, history: [], ...columns, sceneRev: writesScene ? 1 : 0 })
+    .onConflictDoUpdate({
+      target: projectFileContent.fileId,
+      set: writesScene
+        ? { ...columns, sceneRev: sql`${projectFileContent.sceneRev} + 1` }
+        : columns,
+    });
 
   if (!returnContent) {
     await insert;
@@ -111,6 +122,7 @@ export type ProjectFileWithContent = {
   spec: unknown;
   content: unknown;
   history: unknown;
+  sceneRev: number | null;
 };
 
 /** Normalise a left-joined row so a missing content row reads as an empty file. */

--- a/apps/server/src/lib/project-file-write.ts
+++ b/apps/server/src/lib/project-file-write.ts
@@ -1,0 +1,232 @@
+import { db, sql } from "@OpenDiagram/db";
+import type { SQL } from "drizzle-orm";
+
+/**
+ * The one statement that writes a project file.
+ *
+ * Replaces BEGIN / UPDATE / upsert / COMMIT with a single data-modifying CTE.
+ * Four round trips down to one. Sub-statements in a WITH run exactly once and
+ * always to completion, whether or not the primary query reads their output.
+ *
+ * https://www.postgresql.org/docs/17/queries-with.html#QUERIES-WITH-MODIFYING
+ *
+ * Ownership rides the project_file UPDATE. No row out of owned means the file
+ * is missing or not this user's; the content write's FROM owned matches nothing;
+ * the outer SELECT returns nothing. Same three-way answer as before, one trip
+ * instead of four.
+ *
+ * SET lists are built per request. A CASE WHEN would spare the branching but
+ * reads and rewrites the TOASTed scene on every request that does not touch it,
+ * which is worse than the problem being solved.
+ */
+
+export type ProjectFileRow = {
+  id: string;
+  projectId: string;
+  type: "diagram" | "doc";
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ProjectFileContentRow = {
+  scene: unknown;
+  spec: unknown;
+  content: unknown;
+  history: unknown;
+};
+
+export type WriteProjectFileResult =
+  | {
+      status: "ok";
+      file: ProjectFileRow;
+      sceneRev: number | null;
+      /** Present only when returnContent was asked for. */
+      content: ProjectFileContentRow | null;
+    }
+  | { status: "not-found" }
+  /** Only reachable on the delta path: the client's base revision is not current. */
+  | { status: "stale" };
+
+type ContentColumns = {
+  scene?: unknown;
+  spec?: unknown;
+  content?: unknown;
+  history?: unknown[];
+};
+
+export type WriteProjectFileInput = {
+  projectId: string;
+  fileId: string;
+  userId: string;
+  metadata: { name?: string; type?: "diagram" | "doc" };
+  content: ContentColumns;
+  /**
+   * Set when content.scene is a merged delta. Turns the write into a guarded
+   * UPDATE so a stale merge cannot silently overwrite the current scene.
+   */
+  expectedSceneRev?: number;
+  /**
+   * Echo the content columns back. Off for canvas autosave, the agent's spec
+   * write, and chat history write (all fire-and-forget; RETURNING would detoast
+   * a scene just to serialize it to a client that discards it). On for rename
+   * and manual save, which call setActiveFile with the response.
+   */
+  returnContent?: boolean;
+};
+
+/**
+ * pg renders a JS array as a Postgres array literal, not JSON, so every jsonb
+ * value is stringified and cast explicitly. An explicit null reaches the column
+ * as SQL NULL (not jsonb 'null'), which is how a caller clears a column.
+ */
+function jsonb(value: unknown): SQL {
+  if (value === null) return sql`NULL`;
+  return sql`${JSON.stringify(value)}::jsonb`;
+}
+
+const CONTENT_COLUMNS = ["scene", "spec", "content", "history"] as const;
+
+export async function writeProjectFile(
+  input: WriteProjectFileInput,
+): Promise<WriteProjectFileResult> {
+  const { projectId, fileId, userId, metadata, content, expectedSceneRev, returnContent } = input;
+
+  const written = CONTENT_COLUMNS.filter((column) => content[column] !== undefined);
+  const writesScene = written.includes("scene");
+  const echo = returnContent === true;
+
+  const fileSets: SQL[] = [sql`"updated_at" = now()`];
+  if (metadata.name !== undefined) fileSets.push(sql`"name" = ${metadata.name}`);
+  if (metadata.type !== undefined) fileSets.push(sql`"type" = ${metadata.type}`);
+
+  const owned = sql`
+    WITH owned AS (
+      UPDATE "project_file" AS f
+         SET ${sql.join(fileSets, sql`, `)}
+        FROM "project" AS p
+       WHERE f."id" = ${fileId} AND f."project_id" = ${projectId}
+         AND p."id" = ${projectId} AND p."user_id" = ${userId}
+      RETURNING f."id", f."project_id", f."type", f."name", f."created_at", f."updated_at"
+    )`;
+
+  const echoed = echo ? sql`"scene", "spec", "content", "history",` : sql``;
+
+  // Metadata only: skip project_file_content entirely. A rename must not rewrite
+  // a 70 kB TOASTed scene. The caller reads content off a join, not RETURNING.
+  //
+  // LEFT JOIN ON true so a guarded write that matched nothing still returns the
+  // file row, which is what tells stale from not-found below.
+  const statement =
+    written.length === 0
+      ? sql`${owned}
+            SELECT owned.*, ${echoed} cc."scene_rev" AS "content_scene_rev"
+              FROM owned LEFT JOIN "project_file_content" AS cc ON cc."file_id" = owned."id"`
+      : sql`${owned}${
+          expectedSceneRev === undefined
+            ? upsertContent(written, content, writesScene, echo)
+            : guardedContent(written, content, expectedSceneRev, echo)
+        }
+            SELECT owned.*, ${echoed} changed."scene_rev" AS "content_scene_rev"
+              FROM owned LEFT JOIN changed ON true`;
+
+  const result = await db.execute<{
+    id: string;
+    project_id: string;
+    type: "diagram" | "doc";
+    name: string;
+    created_at: Date;
+    updated_at: Date;
+    content_scene_rev: number | null;
+    scene?: unknown;
+    spec?: unknown;
+    content?: unknown;
+    history?: unknown;
+  }>(statement);
+
+  const row = result.rows[0];
+  if (!row) return { status: "not-found" };
+  // File exists and is this user's, but the guarded UPDATE matched nothing.
+  // Revision moved under the client between read and write.
+  if (expectedSceneRev !== undefined && row.content_scene_rev === null) {
+    return { status: "stale" };
+  }
+
+  return {
+    status: "ok",
+    sceneRev: row.content_scene_rev,
+    content: echo
+      ? { scene: row.scene, spec: row.spec, content: row.content, history: row.history }
+      : null,
+    file: {
+      id: row.id,
+      projectId: row.project_id,
+      type: row.type,
+      name: row.name,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    },
+  };
+}
+
+/**
+ * The ordinary write: create the content row if missing, else overwrite the
+ * columns the caller named. Self-repairing: a file whose content row went
+ * missing recovers on its next save instead of failing forever.
+ */
+function upsertContent(
+  written: readonly (keyof ContentColumns)[],
+  content: ContentColumns,
+  writesScene: boolean,
+  echo: boolean,
+): SQL {
+  // history is NOT NULL with no database default, so the INSERT half always
+  // carries one even when the caller said nothing about it.
+  const columns = new Set<string>([...written, "history"]);
+  const names = [...columns].map((column) => sql.raw(`"${column}"`));
+  const values = [...columns].map((column) =>
+    column === "history" && content.history === undefined
+      ? sql`'[]'::jsonb`
+      : jsonb(content[column as keyof ContentColumns]),
+  );
+
+  const sets = written.map((column) => sql.raw(`"${column}" = excluded."${column}"`));
+  if (writesScene) sets.push(sql`"scene_rev" = "project_file_content"."scene_rev" + 1`);
+
+  return sql`, changed AS (
+      INSERT INTO "project_file_content" (${sql.join(names, sql`, `)}, "file_id", "scene_rev")
+      SELECT ${sql.join(values, sql`, `)}, owned."id", ${writesScene ? 1 : 0} FROM owned
+      ON CONFLICT ("file_id") DO UPDATE SET ${sql.join(sets, sql`, `)}
+      RETURNING ${returning(echo)}
+    )`;
+}
+
+/** The content columns a write hands back, which is nothing extra unless asked. */
+function returning(echo: boolean): SQL {
+  return echo ? sql`"scene_rev", "scene", "spec", "content", "history"` : sql`"scene_rev"`;
+}
+
+/**
+ * The delta write: an UPDATE guarded on the revision, not an upsert. A missing
+ * content row means the client's base revision describes a scene that does not
+ * exist; inserting the merge result would present a partial scene as if it were
+ * whole. Matching nothing here is correct, and the 409 makes the client resend
+ * a full snapshot.
+ */
+function guardedContent(
+  written: readonly (keyof ContentColumns)[],
+  content: ContentColumns,
+  expectedSceneRev: number,
+  echo: boolean,
+): SQL {
+  const sets = written.map((column) => sql`${sql.raw(`"${column}"`)} = ${jsonb(content[column])}`);
+  sets.push(sql`"scene_rev" = c."scene_rev" + 1`);
+
+  return sql`, changed AS (
+      UPDATE "project_file_content" AS c
+         SET ${sql.join(sets, sql`, `)}
+        FROM owned
+       WHERE c."file_id" = owned."id" AND c."scene_rev" = ${expectedSceneRev}
+      RETURNING ${returning(echo)}
+    )`;
+}

--- a/apps/server/src/lib/repo-generation.ts
+++ b/apps/server/src/lib/repo-generation.ts
@@ -552,19 +552,22 @@ async function runRepoGenerationJob(
       });
 
       try {
-        // The content write and the parent touch go together: `updatedAt` lives
-        // on `project_file`, so now that the generated output lands in a
-        // different table, writing it alone would leave the file reading as
-        // untouched in the dashboard and the file list.
+        // The content write and the parent touch go together: updatedAt lives on
+        // project_file, so writing the generated output alone would leave the file
+        // reading as untouched in the dashboard and the file list.
+        //
+        // project_file first, and the order is load-bearing: writeProjectFile takes
+        // the same two row locks in that order, so a canvas autosave landing on a
+        // file this job is generating into would deadlock if the two disagreed.
         await db.transaction(async (tx) => {
-          await writeProjectFileContent(tx, fileId, {
-            content,
-            spec: createGeneratedSpec(projectRow, item, "complete"),
-          });
           await tx
             .update(projectFile)
             .set({ updatedAt: new Date() })
             .where(eq(projectFile.id, fileId));
+          await writeProjectFileContent(tx, fileId, {
+            content,
+            spec: createGeneratedSpec(projectRow, item, "complete"),
+          });
         });
       } catch (dbError) {
         logJob(
@@ -630,15 +633,17 @@ async function runRepoGenerationJob(
       }
 
       try {
+        // project_file first, same lock order as writeProjectFile. See the note
+        // on the doc write above.
         await db.transaction(async (tx) => {
-          await writeProjectFileContent(tx, fileId, {
-            scene: diagram.scene,
-            spec: createGeneratedSpec(projectRow, item, "complete", diagram.spec),
-          });
           await tx
             .update(projectFile)
             .set({ updatedAt: new Date() })
             .where(eq(projectFile.id, fileId));
+          await writeProjectFileContent(tx, fileId, {
+            scene: diagram.scene,
+            spec: createGeneratedSpec(projectRow, item, "complete", diagram.spec),
+          });
         });
       } catch (dbError) {
         logJob(

--- a/apps/server/src/lib/scene-delta.ts
+++ b/apps/server/src/lib/scene-delta.ts
@@ -43,7 +43,10 @@ type StoredScene = { elements?: unknown; appState?: unknown; files?: unknown };
 export function isSceneDelta(scene: unknown): boolean {
   if (!scene || typeof scene !== "object") return false;
   const value = scene as { base?: unknown; changed?: unknown };
-  return typeof value.base === "number" && Array.isArray(value.changed);
+  // elements has to be absent, not merely ignored. This runs on a request body,
+  // so a client sending a whole scene that happens to carry base and changed
+  // would otherwise have its elements silently dropped by the merge.
+  return typeof value.base === "number" && Array.isArray(value.changed) && !("elements" in value);
 }
 
 function elementId(element: unknown): string | null {

--- a/apps/server/src/lib/scene-delta.ts
+++ b/apps/server/src/lib/scene-delta.ts
@@ -22,11 +22,12 @@ import { z } from "zod";
 /**
  * A delta is told from a full scene by these two fields, so both are required.
  *
- * A null base means merge unconditionally. Only the unload beacon sends that: it
- * is the one write with nothing alive to read a 409 or retry it, and a keepalive
- * body cannot carry a whole scene instead (64 KiB quota, our scenes average 70).
- * Merging is still the safer half of that trade, since it keeps concurrent
- * changes this client never saw where a full-scene overwrite would drop them.
+ * A null base means "merge onto whatever revision the row holds now". Only the
+ * unload beacon sends that: it is the one write with nothing alive to read a 409
+ * or retry it, and a keepalive body cannot carry a whole scene instead (64 KiB
+ * quota, our scenes average 70). It waives the client's revision check, not the
+ * write's own guard, so a save landing between the merge and the write is still
+ * rejected rather than silently overwritten.
  */
 export const sceneDeltaSchema = z.object({
   base: z.number().int().nonnegative().nullable(),

--- a/apps/server/src/lib/scene-delta.ts
+++ b/apps/server/src/lib/scene-delta.ts
@@ -19,9 +19,17 @@ import { z } from "zod";
  * so the writer behind it can become a PUT without the wire format changing.
  */
 
-/** A delta is told from a full scene by these two fields, so both are required. */
+/**
+ * A delta is told from a full scene by these two fields, so both are required.
+ *
+ * A null base means merge unconditionally. Only the unload beacon sends that: it
+ * is the one write with nothing alive to read a 409 or retry it, and a keepalive
+ * body cannot carry a whole scene instead (64 KiB quota, our scenes average 70).
+ * Merging is still the safer half of that trade, since it keeps concurrent
+ * changes this client never saw where a full-scene overwrite would drop them.
+ */
 export const sceneDeltaSchema = z.object({
-  base: z.number().int().nonnegative(),
+  base: z.number().int().nonnegative().nullable(),
   changed: z.array(z.unknown()),
   appState: z.unknown().optional(),
   files: z.record(z.string(), z.unknown()).optional(),
@@ -46,7 +54,8 @@ export function isSceneDelta(scene: unknown): boolean {
   // elements has to be absent, not merely ignored. This runs on a request body,
   // so a client sending a whole scene that happens to carry base and changed
   // would otherwise have its elements silently dropped by the merge.
-  return typeof value.base === "number" && Array.isArray(value.changed) && !("elements" in value);
+  const hasBase = typeof value.base === "number" || value.base === null;
+  return hasBase && Array.isArray(value.changed) && !("elements" in value);
 }
 
 function elementId(element: unknown): string | null {

--- a/apps/server/src/lib/scene-delta.ts
+++ b/apps/server/src/lib/scene-delta.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+/**
+ * Merging canvas scene deltas.
+ *
+ * The canvas used to PATCH its whole scene on every save (70 kB avg, 248 kB max,
+ * several times a minute). A delta carries only the elements whose Excalidraw
+ * version moved since the client's last acknowledged revision, a couple kB in
+ * the common case.
+ *
+ * Buys wire bytes, not database time. Postgres rewrites the whole TOASTed jsonb
+ * value either way, so write cost is unchanged until the scene moves out of the
+ * row entirely.
+ *
+ * TODO: move scene to R2 and keep only a key + revision on the row. That removes
+ * the TOAST rewrite, the WAL churn, and the 16x bloat on project_file_content.
+ * Both Excalidraw and tldraw hold blobs in object storage keyed by their own id.
+ * This module is the seam: mergeSceneDelta already produces the whole next scene,
+ * so the writer behind it can become a PUT without the wire format changing.
+ */
+
+/** A delta is told from a full scene by these two fields, so both are required. */
+export const sceneDeltaSchema = z.object({
+  base: z.number().int().nonnegative(),
+  changed: z.array(z.unknown()),
+  appState: z.unknown().optional(),
+  files: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type SceneDelta = z.infer<typeof sceneDeltaSchema>;
+
+type SceneElement = { id?: unknown; index?: unknown };
+type StoredScene = { elements?: unknown; appState?: unknown; files?: unknown };
+
+/**
+/** Whether a PATCH body's scene is a delta rather than a whole scene.
+ *
+ * Checked before parsing because scene is z.unknown() on the route. The two
+ * shapes are structurally disjoint (stored scene has elements, delta has base +
+ * changed), and a Zod union over unknown would have to describe the stored scene
+ * too, which nothing else needs.
+ */
+export function isSceneDelta(scene: unknown): boolean {
+  if (!scene || typeof scene !== "object") return false;
+  const value = scene as { base?: unknown; changed?: unknown };
+  return typeof value.base === "number" && Array.isArray(value.changed);
+}
+
+function elementId(element: unknown): string | null {
+  if (!element || typeof element !== "object") return null;
+  const id = (element as SceneElement).id;
+  return typeof id === "string" ? id : null;
+}
+
+/**
+ * Order by Excalidraw's fractional index, the way orderByFractionalIndex does.
+ *
+ * Z-order is carried on the element as index ("a0", "c1PO"), not by array
+ * position. zindex.ts reorders through syncMovedIndices -> mutateElement, which
+ * bumps version. So a send-to-back arrives in the delta like any other edit and
+ * needs no separate ordering channel.
+ *
+ * Sorting is skipped unless every element carries an index. Scenes drawn before
+ * fractional indices existed have none; for those the array order IS the z-order,
+ * sorting them would shuffle the canvas.
+ */
+function orderElements(elements: unknown[]): unknown[] {
+  const indexOf = (element: unknown) => (element as SceneElement | null)?.index as string;
+  if (!elements.every((element) => typeof indexOf(element) === "string")) return elements;
+
+  return [...elements].sort((a, b) => {
+    if (indexOf(a) !== indexOf(b)) return indexOf(a) < indexOf(b) ? -1 : 1;
+    // Same tie-break as upstream, so two clients that both hold a duplicated
+    // index still agree on the resulting order.
+    return (elementId(a) ?? "").localeCompare(elementId(b) ?? "");
+  });
+}
+
+/**
+ * Apply a delta to the stored scene, returning the whole next scene.
+ *
+ * Deletions need no channel of their own: Excalidraw marks a removed element
+ * isDeleted: true and bumps its version rather than dropping it from the array,
+ * so a deletion arrives as an ordinary changed element. Tombstones are never
+ * collected; upstream expires them at DELETED_ELEMENT_TIMEOUT (24h) and we have
+ * no equivalent yet.
+ *
+ * appState is ~1 kB of viewport and theme, replaced wholesale. files is merged
+ * rather than replaced, because a delta only carries blobs the client knows the
+ * server has not seen.
+ */
+export function mergeSceneDelta(current: unknown, delta: SceneDelta): unknown {
+  const stored = (current ?? {}) as StoredScene;
+  const elements = Array.isArray(stored.elements) ? [...stored.elements] : [];
+
+  const positions = new Map<string, number>();
+  elements.forEach((element, position) => {
+    const id = elementId(element);
+    if (id !== null) positions.set(id, position);
+  });
+
+  for (const element of delta.changed) {
+    const id = elementId(element);
+    if (id === null) continue;
+    const position = positions.get(id);
+    if (position === undefined) {
+      positions.set(id, elements.length);
+      elements.push(element);
+    } else {
+      elements[position] = element;
+    }
+  }
+
+  const files = { ...(stored.files as Record<string, unknown>), ...delta.files };
+
+  return {
+    elements: orderElements(elements),
+    appState: delta.appState ?? stored.appState,
+    files,
+  };
+}

--- a/apps/server/src/routes/projects/files.ts
+++ b/apps/server/src/routes/projects/files.ts
@@ -239,7 +239,11 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
       );
 
     if (!current) return c.json({ error: "Not found" }, 404);
-    if (current.type === "doc") nextSpec = markDocSpecUserEdited(current.spec ?? null);
+    // The type after this write, not before it. A request that converts a diagram
+    // to a doc and supplies the body in one go still owes the spec its stamp.
+    if ((metadata.type ?? current.type) === "doc") {
+      nextSpec = markDocSpecUserEdited(current.spec ?? null);
+    }
   }
 
   const result = await writeProjectFile({
@@ -253,10 +257,10 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
   });
 
   if (result.status === "not-found") return c.json({ error: "Not found" }, 404);
-  // Revision moved between the merge above and the write. The client answers by
-  // dropping its baseline and resending the whole scene, so there is nothing useful
-  // to put in the body (shipping the current scene back would cost the 70 kB this
-  // endpoint exists to avoid).
+  // Empty body on purpose: the client answers a 409 by resending the whole scene,
+  // so returning the current one would cost the 70 kB this endpoint exists to
+  // avoid. Note the write already advanced updatedAt even though the scene did not
+  // land, since both are sub-statements of one statement. See project-file-write.
   if (result.status === "stale") return c.json({ error: "Stale scene revision" }, 409);
 
   const row = { ...result.file, sceneRev: result.sceneRev };

--- a/apps/server/src/routes/projects/files.ts
+++ b/apps/server/src/routes/projects/files.ts
@@ -8,7 +8,9 @@ import {
   withContentDefaults,
   writeProjectFileContent,
 } from "../../lib/project-file-content";
+import { writeProjectFile } from "../../lib/project-file-write";
 import type { AuthVariables } from "../../lib/require-auth";
+import { isSceneDelta, mergeSceneDelta, sceneDeltaSchema } from "../../lib/scene-delta";
 
 const fileTypeSchema = z.enum(["diagram", "doc"]);
 
@@ -32,7 +34,7 @@ const updateFileSchema = z
   })
   .refine((value) => Object.keys(value).length > 0, { message: "No fields to update" });
 
-/** The columns a file list returns -- never the large ones in `project_file_content`. */
+/** The columns a file list returns; never the large ones in project_file_content. */
 const fileListColumns = {
   id: projectFile.id,
   projectId: projectFile.projectId,
@@ -65,13 +67,13 @@ filesRoute.get("/:projectId/files", async (c) => {
   const userId = c.get("userId");
   const projectId = c.req.param("projectId");
 
-  // Driven from `project` with a left join rather than selecting files directly,
+  // Driven from project with a left join rather than selecting files directly,
   // so a single round trip still separates the two failure modes: no rows means
   // the project is missing or not this user's (404), while one row with a null
   // file means the project is real and merely empty ([]). Selecting straight
-  // from `project_file` would answer both with an empty list, and this route is
-  // the most-called in the app -- the ownership pre-check it replaces was a
-  // second sequential round trip on every canvas and dashboard load.
+  // from project_file would answer both with an empty list, and this route is the
+  // most-called in the app (the ownership pre-check it replaces was a second
+  // sequential round trip on every canvas and dashboard load).
   const rows = await db
     .select({ file: fileListColumns })
     .from(project)
@@ -96,11 +98,11 @@ filesRoute.post("/:projectId/files", async (c) => {
     return c.json({ error: "Invalid request", issues: parsed.error.issues }, 400);
   }
 
-  // TODO: 5 round trips -- this select, then BEGIN/INSERT/INSERT/COMMIT.
+  // TODO: 5 round trips (this select, then BEGIN/INSERT/INSERT/COMMIT).
   // Measured at ~1.5s against us-east-2. Collapsible to 1 with a CTE that does
   // ownership, file insert and content insert together. Left for a later
   // session: the route runs a few times a month, and folding the check into
-  // `INSERT ... SELECT ... WHERE EXISTS` would blur "not found" into
+  // INSERT ... SELECT ... WHERE EXISTS would blur "not found" into
   // "insert failed".
   const [projectRow] = await db
     .select({ id: project.id })
@@ -140,7 +142,7 @@ filesRoute.get("/:projectId/files/:fileId", async (c) => {
   const projectId = c.req.param("projectId");
   const fileId = c.req.param("fileId");
   // The one route that wants the large columns, so the only one that joins to
-  // `project_file_content`. Left-joined: a missing content row reads as an empty
+  // project_file_content. Left-joined: a missing content row reads as an empty
   // file rather than a 404 on a file the list just showed.
   const [row] = await db
     .select(selectProjectFileColumns())
@@ -156,6 +158,18 @@ filesRoute.get("/:projectId/files/:fileId", async (c) => {
   return c.json({ file: withContentDefaults(row) });
 });
 
+/**
+ * The only writer of project_file_content, and the busiest route in the app.
+ *
+ * scene arrives in one of two shapes: a whole scene, or a delta of the elements
+ * whose Excalidraw version moved since base (see lib/scene-delta.ts). A delta
+ * answers 409 when base is not the current revision, which is the client's cue
+ * to drop its baseline and resend a whole scene (no body worth reading comes
+ * back with it).
+ *
+ * Last-writer-wins throughout, matching the local-first canvas. The response
+ * carries sceneRev whenever the content row was touched.
+ */
 filesRoute.patch("/:projectId/files/:fileId", async (c) => {
   const userId = c.get("userId");
   const projectId = c.req.param("projectId");
@@ -169,78 +183,88 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
 
   const { scene, spec, content, history, ...metadata } = parsed.data;
 
-  // `?fields=meta` drops the content echo from the response. The write paths that
-  // use it -- canvas autosave, the agent's spec write, the chat history write --
-  // are all replication behind a local write and read nothing back, yet each was
+  // ?fields=meta drops the content echo from the response. The write paths that
+  // use it (canvas autosave, agent spec write, chat history write) are all
+  // replication behind a local write and read nothing back, yet each was
   // downloading the scene it had just uploaded. A rename paid 12.8KB to change 15
-  // bytes. Opt-in rather than the default because `useWorkspaceFileActions` and
-  // `useWorkspaceFileName` do `setActiveFile(updated)` and read `updated.content`,
-  // so stripping it unconditionally would blank the editor.
+  // bytes. Opt-in rather than default because useWorkspaceFileActions and
+  // useWorkspaceFileName do setActiveFile(updated) and read updated.content, so
+  // stripping it unconditionally would blank the editor.
   const metaOnly = c.req.query("fields") === "meta";
 
-  // TODO: still 4 round trips -- BEGIN, UPDATE, content upsert, COMMIT. A single
-  // CTE would be atomic without the explicit transaction, so 1. Needs either
-  // dynamically built SQL or a `CASE WHEN $flag` per content column, since the
-  // columns are written conditionally. Measured against us-east-2 at 285ms per
-  // round trip from India, ~18ms once the DB is co-located with Cloud Run.
-  const row = await db.transaction(async (tx) => {
-    // Ownership rides on the UPDATE instead of a select in front of it: no row
-    // back means the file is missing or the project isn't this user's. `type`
-    // comes back with it for the doc stamp below.
-    //
-    // `updatedAt` is set explicitly rather than left to `$onUpdate` because the
-    // canvas PATCH usually carries `scene` alone -- `metadata` is then `{}`, and
-    // drizzle rejects an update with no columns to set. It is always written,
-    // even for a content-only change, since it drives the dashboard ordering.
-    const [file] = await tx
-      .update(projectFile)
-      .set({ ...metadata, updatedAt: new Date() })
-      .from(project)
-      .where(
-        and(
-          eq(projectFile.id, fileId),
-          eq(projectFile.projectId, projectId),
-          eq(project.id, projectId),
-          eq(project.userId, userId),
-        ),
-      )
-      .returning(fileListColumns);
-
-    if (!file) return null;
-
-    // Editing a doc's body stamps the spec so the generator knows a human has
-    // touched it. Read here rather than in the ownership select it replaced:
-    // `spec` is a TOASTed column and every canvas autosave was paying to fetch
-    // one it never looked at. Keyed on the value, not `"content" in parsed.data`
-    // -- an optional Zod field can arrive as an explicit `undefined`, which key
-    // presence would read as an edit.
-    let nextSpec = spec;
-    if (file.type === "doc" && content !== undefined) {
-      const [existing] = await tx
-        .select({ spec: projectFileContent.spec })
-        .from(projectFileContent)
-        .where(eq(projectFileContent.fileId, fileId));
-      nextSpec = markDocSpecUserEdited(existing?.spec ?? null);
-    }
-
-    const contentRow = await writeProjectFileContent(
-      tx,
-      fileId,
-      { scene, spec: nextSpec, content, history },
-      { returnContent: !metaOnly },
-    );
-
-    return { ...file, ...contentRow };
-  });
-
-  if (!row) {
-    return c.json({ error: "Not found" }, 404);
+  const delta = isSceneDelta(scene) ? sceneDeltaSchema.safeParse(scene) : null;
+  if (delta && !delta.success) {
+    return c.json({ error: "Invalid scene delta", issues: delta.error.issues }, 400);
   }
 
-  // `withContentDefaults` normalises a missing content row to `history: []`, which
-  // is exactly the wrong thing for a meta response -- it would tell the client the
-  // chat history is empty when it simply was not asked for.
-  return c.json({ file: metaOnly ? row : withContentDefaults(row) });
+  // The only two writes that have to see the current row before building the next
+  // one. Everything else (the overwhelming majority of traffic) goes straight to
+  // the single-statement write below.
+  let nextScene = scene;
+  let nextSpec = spec;
+  let expectedSceneRev: number | undefined;
+
+  if (delta?.success) {
+    const [current] = await db
+      .select({ scene: projectFileContent.scene, sceneRev: projectFileContent.sceneRev })
+      .from(projectFile)
+      .innerJoin(project, eq(projectFile.projectId, project.id))
+      .leftJoin(projectFileContent, projectFileContentJoin)
+      .where(
+        and(eq(project.id, projectId), eq(project.userId, userId), eq(projectFile.id, fileId)),
+      );
+
+    if (!current) return c.json({ error: "Not found" }, 404);
+    if ((current.sceneRev ?? 0) !== delta.data.base) {
+      return c.json({ error: "Stale scene revision" }, 409);
+    }
+
+    nextScene = mergeSceneDelta(current.scene, delta.data);
+    // Re-checked inside the write as well. This comparison is against a snapshot
+    // that another request can invalidate before the write lands; the guard on the
+    // statement itself is what actually makes it safe.
+    expectedSceneRev = delta.data.base;
+  } else if (content !== undefined) {
+    // Editing a doc's body stamps the spec so the generator knows a human touched
+    // it. Keyed on the value, not "content" in parsed.data (an optional Zod field
+    // can arrive as explicit undefined, which key presence would read as an edit).
+    // spec is TOASTed, so this read is kept off every canvas autosave.
+    const [current] = await db
+      .select({ type: projectFile.type, spec: projectFileContent.spec })
+      .from(projectFile)
+      .innerJoin(project, eq(projectFile.projectId, project.id))
+      .leftJoin(projectFileContent, projectFileContentJoin)
+      .where(
+        and(eq(project.id, projectId), eq(project.userId, userId), eq(projectFile.id, fileId)),
+      );
+
+    if (!current) return c.json({ error: "Not found" }, 404);
+    if (current.type === "doc") nextSpec = markDocSpecUserEdited(current.spec ?? null);
+  }
+
+  const result = await writeProjectFile({
+    projectId,
+    fileId,
+    userId,
+    metadata,
+    content: { scene: nextScene, spec: nextSpec, content, history },
+    expectedSceneRev,
+    returnContent: !metaOnly,
+  });
+
+  if (result.status === "not-found") return c.json({ error: "Not found" }, 404);
+  // Revision moved between the merge above and the write. The client answers by
+  // dropping its baseline and resending the whole scene, so there is nothing useful
+  // to put in the body (shipping the current scene back would cost the 70 kB this
+  // endpoint exists to avoid).
+  if (result.status === "stale") return c.json({ error: "Stale scene revision" }, 409);
+
+  const row = { ...result.file, sceneRev: result.sceneRev };
+
+  // withContentDefaults normalises a missing content row to history: [], which is
+  // exactly the wrong thing for a meta response (it would tell the client chat
+  // history is empty when it simply was not asked for).
+  return c.json({ file: metaOnly ? row : withContentDefaults({ ...row, ...result.content }) });
 });
 
 filesRoute.delete("/:projectId/files/:fileId", async (c) => {
@@ -248,7 +272,7 @@ filesRoute.delete("/:projectId/files/:fileId", async (c) => {
   const projectId = c.req.param("projectId");
   const fileId = c.req.param("fileId");
 
-  // The content row goes with it via the cascade on `file_id`.
+  // The content row goes with it via the cascade on file_id.
   const [row] = await db
     .delete(projectFile)
     .where(

--- a/apps/server/src/routes/projects/files.ts
+++ b/apps/server/src/routes/projects/files.ts
@@ -215,7 +215,9 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
       );
 
     if (!current) return c.json({ error: "Not found" }, 404);
-    if ((current.sceneRev ?? 0) !== delta.data.base) {
+    // A null base is the unload beacon opting out of the guard, because nothing
+    // is alive to act on a 409. See sceneDeltaSchema.
+    if (delta.data.base !== null && (current.sceneRev ?? 0) !== delta.data.base) {
       return c.json({ error: "Stale scene revision" }, 409);
     }
 
@@ -223,7 +225,7 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
     // Re-checked inside the write as well. This comparison is against a snapshot
     // that another request can invalidate before the write lands; the guard on the
     // statement itself is what actually makes it safe.
-    expectedSceneRev = delta.data.base;
+    expectedSceneRev = delta.data.base ?? undefined;
   } else if (content !== undefined) {
     // Editing a doc's body stamps the spec so the generator knows a human touched
     // it. Keyed on the value, not "content" in parsed.data (an optional Zod field

--- a/apps/server/src/routes/projects/files.ts
+++ b/apps/server/src/routes/projects/files.ts
@@ -215,9 +215,12 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
       );
 
     if (!current) return c.json({ error: "Not found" }, 404);
-    // A null base is the unload beacon opting out of the guard, because nothing
-    // is alive to act on a 409. See sceneDeltaSchema.
-    if (delta.data.base !== null && (current.sceneRev ?? 0) !== delta.data.base) {
+    // A null base is the unload beacon, which cannot wait to learn the current
+    // revision, so it merges onto whatever the row holds. A base that is still
+    // null after that is a file with no content row: the changed elements are a
+    // fragment, and inserting them would stand in for a whole scene.
+    const base = delta.data.base ?? current.sceneRev;
+    if (base === null || (current.sceneRev ?? 0) !== base) {
       return c.json({ error: "Stale scene revision" }, 409);
     }
 
@@ -225,7 +228,7 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
     // Re-checked inside the write as well. This comparison is against a snapshot
     // that another request can invalidate before the write lands; the guard on the
     // statement itself is what actually makes it safe.
-    expectedSceneRev = delta.data.base ?? undefined;
+    expectedSceneRev = base;
   } else if (content !== undefined) {
     // Editing a doc's body stamps the spec so the generator knows a human touched
     // it. Keyed on the value, not "content" in parsed.data (an optional Zod field

--- a/apps/web/src/components/whiteboard/workspace-layout/helpers.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/helpers.ts
@@ -6,12 +6,17 @@ export const SIDEBAR_MAX_WIDTH = 360;
 export const AGENT_MIN_WIDTH = 300;
 export const AGENT_MAX_WIDTH = 560;
 export const CONTENT_MIN_WIDTH = 420;
-// Was 800 ms, chosen when the network write was the only durable copy and so
-// had to be hurried. IndexedDB now takes the edit immediately (see
-// `useWorkspacePersistence`), which makes this purely the replication interval:
-// a longer window collapses a burst of drawing into one request and, with
-// single-flight, keeps at most one PATCH per file on the wire.
-export const AUTOSAVE_DELAY_MS = 2500;
+// A rate ceiling, not a quiet period. scheduleAutosave throttles on it rather
+// than debouncing. As a 2500 ms trailing debounce this was the single biggest
+// source of server traffic: real drawing is full of pauses longer than that, so
+// every one became a request. One session measured 197 PATCHes against ~500 total
+// API calls. A throttle bounds the rate no matter how the input arrives.
+//
+// 15 s is affordable because IndexedDB, not the server, is what makes an edit
+// durable (see useWorkspacePersistence); the PATCH is replication. Excalidraw
+// ships a 20 s interval (SYNC_FULL_SCENE_INTERVAL_MS) backed only by localStorage,
+// and we additionally reconcile a dirty local copy on open.
+export const AUTOSAVE_THROTTLE_MS = 15000;
 
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -85,7 +90,7 @@ export function hasDiagramSpec(value: unknown) {
   );
 }
 
-/** `collaborators` is a Map and does not survive a JSON round trip. */
+/** collaborators is a Map and does not survive a JSON round trip. */
 export function sanitizeSceneAppState(appState: unknown) {
   if (!appState || typeof appState !== "object") return appState;
 
@@ -97,7 +102,7 @@ export function sanitizeSceneAppState(appState: unknown) {
 /**
  * Whether a saved scene already knows where the camera should sit.
  *
- * `Whiteboard.tsx` hands the stored appState to Excalidraw as `initialData`, so a
+ * Whiteboard.tsx hands the stored appState to Excalidraw as initialData, so a
  * scene carrying a zoom is positioned correctly at first paint with no work from
  * us. Auto-fitting on top of that is what produced the "opens on one diagram, then
  * zooms out" jump: the fit runs from a promise chain that resolves whole seconds
@@ -105,16 +110,16 @@ export function sanitizeSceneAppState(appState: unknown) {
  * canvas, zoom 0.5 -> 0.3, landing after the chat panel had finished scrolling).
  *
  * So the fit is now the fallback rather than the default: it runs only for a scene
- * with no viewport of its own -- an import, or anything drawn before viewports were
- * stored -- where the alternative is opening on Excalidraw's origin and possibly
+ * with no viewport of its own (an import, or anything drawn before viewports were
+ * stored), where the alternative is opening on Excalidraw's origin and possibly
  * showing nothing at all.
  */
 export function sceneHasSavedViewport(appState: unknown) {
   if (!appState || typeof appState !== "object") return false;
 
   // All three, not just the zoom: a zoom alone does not say where the camera is,
-  // so such a scene skipped the fit and opened at the origin -- an empty screen
-  // for any diagram laid out away from it.
+  // so such a scene skipped the fit and opened at the origin (an empty screen for
+  // any diagram laid out away from it).
   const { zoom, scrollX, scrollY } = appState as {
     zoom?: { value?: unknown };
     scrollX?: unknown;

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceFileActions.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceFileActions.ts
@@ -83,8 +83,8 @@ export function useWorkspaceFileActions(options: FileActionsOptions) {
     try {
       // Through the shared queue, like the autosave it replaces: direct, it put a
       // second scene PATCH on the wire against a row an autosave was already
-      // writing -- pressing Save inside the 2.5 s debounce. `clearAutosave` above
-      // stops a NEW one being scheduled, it does not recall a queued one.
+      // writing -- pressing Save inside the autosave interval. `clearAutosave`
+      // above stops a NEW one being scheduled, it does not recall a queued one.
       //
       // "full" because the response is read back below to re-seed a doc editor.
       const updated = await queueProjectFilePatch(

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -4,7 +4,7 @@ import { env } from "@OpenDiagram/env/web";
 import { saveGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
 import { writeLocalScene } from "@/lib/local-scene";
 import { queueProjectFilePatch } from "@/lib/project-file-sync";
-import { encodeScene, resetSceneDelta } from "@/lib/scene-delta";
+import { resetSceneDelta } from "@/lib/scene-delta";
 import { type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import {
@@ -265,14 +265,12 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // Encoded before the baseline is dropped, so a navigation that also ran the
-      // hidden flush duplicates a ~2 kB delta rather than a 70 kB scene. Both carry
-      // the same base, so whichever lands second is a 409 that writes nothing.
-      // The baseline goes after, because nothing here reads the new sceneRev back.
-      const scene =
-        snapshot.file.type === "diagram"
-          ? encodeScene(snapshot.file.id, snapshot.scene).wire
-          : undefined;
+      // Whole scene, never a delta, and that is not an oversight. This is the only
+      // write with no follow-up, so it cannot be revision-gated: an autosave that
+      // commits between this encode and its arrival would leave the beacon 409ing
+      // with nothing alive to retry it, silently stranding the newest edit on the
+      // device. Unconditional costs ~70 kB once per unload, which is not the
+      // traffic this file exists to reduce.
       resetSceneDelta(snapshot.file.id);
       void fetch(
         `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${snapshot.file.id}?fields=meta`,
@@ -282,7 +280,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
           keepalive: true,
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            scene,
+            scene: snapshot.file.type === "diagram" ? snapshot.scene : undefined,
             content: snapshot.file.type === "doc" ? snapshot.content : undefined,
           }),
         },

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -118,14 +118,10 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
 
   const snapshotRef = useRef<SaveSnapshot | null>(null);
   const inFlightRef = useRef(false);
-  /** The version the visibilitychange flush sent, so pagehide can skip it. */
-  const hideFlushedVersionRef = useRef<string | null>(null);
 
-  // Clearing the handle is the half that matters, not the clearTimeout.
-  // scheduleAutosave treats a non-null handle as "an interval is already running"
-  // and declines to arm another, so a cancelled timer left set would wedge
-  // autosave for the rest of the session. Harmless under the old debounce, which
-  // reassigned the handle unconditionally.
+  // Nulling the handle is the half that matters. scheduleAutosave reads a non-null
+  // handle as "already running" and declines to arm another, so a cancelled timer
+  // left set wedges autosave for the session. Harmless under the old debounce.
   const cancelPendingAutosave = useCallback(() => {
     if (!autosaveTimer.current) return;
     clearTimeout(autosaveTimer.current);
@@ -145,12 +141,10 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
 
     inFlightRef.current = true;
     try {
-      // Stops draining once an interval is armed, or the throttle ceiling would
-      // not hold: an edit arriving mid-request arms a timer AND queues a
-      // snapshot, and draining that snapshot on completion puts a second PATCH
-      // on the wire seconds after the first. Leaving it for the armed timer is
-      // what keeps the rate at one per interval. The loop still runs when
-      // nothing is armed, so a snapshot is never stranded.
+      // Stops once an interval is armed, or the ceiling breaks: an edit arriving
+      // mid-request arms a timer and queues a snapshot, and draining it here would
+      // send a second PATCH seconds after the first. Still drains when none is
+      // armed, so nothing is stranded.
       while (snapshotRef.current && !autosaveTimer.current) {
         const snapshot = snapshotRef.current;
         snapshotRef.current = null;
@@ -245,48 +239,35 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
     [currentFileIdRef, draftRef, scheduleAutosave, setDocContent, setDraft],
   );
 
-  // The two end-of-session signals, which do different things on purpose.
-  //
-  // visibilitychange -> hidden is the only one that fires when a tab is closed
-  // from the mobile tab switcher or the browser is killed from the app switcher,
-  // and with a 15 s interval instead of 2.5 s the window it covers is six times
-  // wider. It runs the ordinary save: the page survives a tab switch, so the
-  // response lands and the scene-delta bookkeeping stays in step with the server.
-  //
-  // pagehide is the last resort and cannot read a response, so it posts a full
-  // snapshot outside the queue and drops the delta baseline (see below).
+  // The only signal that fires when a tab is closed from the mobile tab switcher,
+  // and the 15 s interval makes the window it covers six times wider than before.
+  // Runs the ordinary save rather than a beacon: a tab switch leaves the page
+  // alive, so the response lands and the delta baseline stays in step.
   useEffect(() => {
     function flushOnHide() {
       if (document.visibilityState !== "hidden") return;
       if (!isSignedInRef.current || !dirtyRef.current) return;
       cancelPendingAutosave();
       snapshotRef.current ??= snapshotCurrent();
-      hideFlushedVersionRef.current = pendingVersionRef.current;
       void runAutosave();
     }
     document.addEventListener("visibilitychange", flushOnHide);
     return () => document.removeEventListener("visibilitychange", flushOnHide);
   }, [cancelPendingAutosave, runAutosave, snapshotCurrent]);
 
+  // Outside the queue and keepalive, because pagehide may not survive another
+  // microtask. Duplicates the hidden flush when both fire, on purpose: dirtyRef is
+  // the only honest "it landed" signal, and suppressing on anything cheaper drops
+  // saves that were merely queued or that failed.
   useEffect(() => {
     function flush() {
       const file = activeFileRef.current;
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // A navigation fires visibilitychange -> hidden and then pagehide, so without
-      // this the same edit went out twice, and the full scene could land first and
-      // leave the delta to 409 and retry over a newer write.
-      if (hideFlushedVersionRef.current === snapshot.version) return;
-      // Deliberately not through the queue: this fires on pagehide, where the page
-      // may not live long enough to run another microtask. A direct keepalive fetch
-      // is handed to the browser to finish after teardown. fields=meta because
-      // nothing is left alive to read the response.
-      //
-      // A full scene, never a delta, and the baseline is dropped: the response
-      // carrying the new sceneRev is never read, so a page restored from bfcache
-      // would otherwise send its next delta against a revision the server has
-      // already moved past.
+      // Whole scene, and the baseline goes first: nothing here reads the sceneRev
+      // back, so a page restored from bfcache would otherwise delta against a
+      // revision the server has moved past.
       resetSceneDelta(snapshot.file.id);
       void fetch(
         `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${snapshot.file.id}?fields=meta`,
@@ -325,9 +306,6 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       }
       cancelPendingAutosave();
       snapshotRef.current = null;
-      // Two empty files share a version string, so a stale value here would let
-      // one file's hide-flush suppress another's pagehide save.
-      hideFlushedVersionRef.current = null;
       sceneRef.current = type === "diagram" ? scene : null;
       contentRef.current = type === "doc" ? content : "";
       lastSavedVersionRef.current = initialElementsVersion(sceneRef.current);

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -265,15 +265,16 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // Unguarded delta, which is the only shape this path can use. A whole scene
+      // A delta that names no base, the only shape this path can use. A whole scene
       // does not fit: keepalive bodies share a 64 KiB quota and our scenes average
       // 70 kB, so the fetch is rejected before it leaves, and `void` swallows it.
-      // A guarded delta would 409 whenever an autosave commits first, with nothing
-      // alive to read the response or retry. So: small enough to send, and
-      // unconditional. https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+      // A delta carrying this client's revision would 409 whenever an autosave
+      // commits first, with nothing alive to read the response or retry; naming no
+      // base merges onto whatever the server holds instead.
+      // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
       const scene =
         snapshot.file.type === "diagram"
-          ? encodeScene(snapshot.file.id, snapshot.scene, { guarded: false }).wire
+          ? encodeScene(snapshot.file.id, snapshot.scene, { withBase: false }).wire
           : undefined;
       resetSceneDelta(snapshot.file.id);
       void fetch(

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -118,6 +118,8 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
 
   const snapshotRef = useRef<SaveSnapshot | null>(null);
   const inFlightRef = useRef(false);
+  /** The version the visibilitychange flush sent, so pagehide can skip it. */
+  const hideFlushedVersionRef = useRef<string | null>(null);
 
   // Clearing the handle is the half that matters, not the clearTimeout.
   // scheduleAutosave treats a non-null handle as "an interval is already running"
@@ -143,7 +145,13 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
 
     inFlightRef.current = true;
     try {
-      while (snapshotRef.current) {
+      // Stops draining once an interval is armed, or the throttle ceiling would
+      // not hold: an edit arriving mid-request arms a timer AND queues a
+      // snapshot, and draining that snapshot on completion puts a second PATCH
+      // on the wire seconds after the first. Leaving it for the armed timer is
+      // what keeps the rate at one per interval. The loop still runs when
+      // nothing is armed, so a snapshot is never stranded.
+      while (snapshotRef.current && !autosaveTimer.current) {
         const snapshot = snapshotRef.current;
         snapshotRef.current = null;
         await saveSnapshot(snapshot);
@@ -253,6 +261,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       if (!isSignedInRef.current || !dirtyRef.current) return;
       cancelPendingAutosave();
       snapshotRef.current ??= snapshotCurrent();
+      hideFlushedVersionRef.current = pendingVersionRef.current;
       void runAutosave();
     }
     document.addEventListener("visibilitychange", flushOnHide);
@@ -265,6 +274,10 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
+      // A navigation fires visibilitychange -> hidden and then pagehide, so without
+      // this the same edit went out twice, and the full scene could land first and
+      // leave the delta to 409 and retry over a newer write.
+      if (hideFlushedVersionRef.current === snapshot.version) return;
       // Deliberately not through the queue: this fires on pagehide, where the page
       // may not live long enough to run another microtask. A direct keepalive fetch
       // is handed to the browser to finish after teardown. fields=meta because
@@ -312,6 +325,9 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       }
       cancelPendingAutosave();
       snapshotRef.current = null;
+      // Two empty files share a version string, so a stale value here would let
+      // one file's hide-flush suppress another's pagehide save.
+      hideFlushedVersionRef.current = null;
       sceneRef.current = type === "diagram" ? scene : null;
       contentRef.current = type === "doc" ? content : "";
       lastSavedVersionRef.current = initialElementsVersion(sceneRef.current);

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -4,10 +4,11 @@ import { env } from "@OpenDiagram/env/web";
 import { saveGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
 import { writeLocalScene } from "@/lib/local-scene";
 import { queueProjectFilePatch } from "@/lib/project-file-sync";
+import { resetSceneDelta } from "@/lib/scene-delta";
 import { type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import {
-  AUTOSAVE_DELAY_MS,
+  AUTOSAVE_THROTTLE_MS,
   initialElementsVersion,
   sanitizeSceneAppState,
   sceneElementsVersion,
@@ -61,10 +62,11 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
     async (snapshot: SaveSnapshot) => {
       if (invalidatedFileIdsRef.current.has(snapshot.file.id)) return;
       try {
-        // Through the shared queue, so this coalesces with the `spec` and chat
-        // history writes the agent fires against the same row -- three requests
-        // per diagram turn became one. `"meta"` because everything read back
-        // below (`updatedAt`, and `id/name/type` for `toSidebarFile`) is metadata;
+        // Through the shared queue, so this coalesces with the spec and chat
+        // history writes the agent fires against the same row (three requests per
+        // diagram turn became one), and updateProjectFile below narrows the scene to
+        // a delta. meta because everything read back below (updatedAt, and
+        // id/name/type for toSidebarFile) is metadata;
         // the full form was shipping the scene back down on every autosave.
         const updated = await queueProjectFilePatch(
           projectId,
@@ -82,7 +84,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
           setSaveStatus("saved");
         }
         // Clear the local dirty flag only once the server has taken the write,
-        // and stamp the server's own `updatedAt` so the next open compares the
+        // and stamp the server's own updatedAt so the next open compares the
         // two copies on the same clock rather than on this device's.
         void writeLocalScene({
           fileId: snapshot.file.id,
@@ -117,15 +119,25 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
   const snapshotRef = useRef<SaveSnapshot | null>(null);
   const inFlightRef = useRef(false);
 
+  // Clearing the handle is the half that matters, not the clearTimeout.
+  // scheduleAutosave treats a non-null handle as "an interval is already running"
+  // and declines to arm another, so a cancelled timer left set would wedge
+  // autosave for the rest of the session. Harmless under the old debounce, which
+  // reassigned the handle unconditionally.
+  const cancelPendingAutosave = useCallback(() => {
+    if (!autosaveTimer.current) return;
+    clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = null;
+  }, []);
+
   // Single-flight. Autosave used to fire on a bare timer, so drawing without
-  // pausing put overlapping PATCHes of the same file on the wire with no
-  // ordering guarantee beyond whichever response happened to land last. Now a
-  // save in progress simply leaves the newest snapshot queued and picks it up
-  // on completion, which also collapses a burst of edits into one request.
+  // pausing put overlapping PATCHes on the wire with no ordering guarantee. Now a
+  // save in progress leaves the newest snapshot queued and picks it up on
+  // completion, collapsing a burst of edits into one request.
   //
   // Drains in a loop rather than calling itself back through a ref. The ref
-  // version had to be reassigned on every render to stay current, and a write
-  // to `ref.current` during render can leak out of work React discards.
+  // version had to be reassigned on every render to stay current, and a write to
+  // ref.current during render can leak out of work React discards.
   const runAutosave = useCallback(async () => {
     if (inFlightRef.current) return;
 
@@ -144,14 +156,15 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
   const scheduleAutosave = useCallback(() => {
     dirtyRef.current = true;
     setSaveStatus("saving");
-    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
     const snapshot = snapshotCurrent();
+    // Assigned before either guard below returns, so whichever save eventually runs
+    // sends the newest state rather than the state that armed the timer.
     snapshotRef.current = snapshot;
 
     // The durable write happens here, not in the request. IndexedDB takes it in
-    // about a millisecond, so the edit survives a refresh, a crash or an offline
-    // stretch the moment it is made; the PATCH below is replication, not saving.
-    // That is what lets the debounce grow without the user risking anything.
+    // about a millisecond, so the edit survives a refresh, a crash, or an offline
+    // stretch the moment it is made. The PATCH below is replication, not saving.
+    // That is what lets the interval grow without the user risking anything.
     if (snapshot) {
       void writeLocalScene({
         fileId: snapshot.file.id,
@@ -164,7 +177,23 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       });
     }
 
-    autosaveTimer.current = setTimeout(() => void runAutosave(), AUTOSAVE_DELAY_MS);
+    // Excalidraw's LocalData.isSavePaused: a hidden tab replicates nothing.
+    // The local write above already happened and the snapshot stays queued, so the
+    // visibilitychange flush that fired alongside this picks it up.
+    if (document.hidden) return;
+
+    // Throttle, not debounce. Re-arming the timer on every change is what made a
+    // 2500 ms delay fire on every pause in drawing instead of bounding the rate.
+    // Bailing while one is pending caps this at one PATCH per interval no matter
+    // how the edits arrive. Same shape as tldraw's TLLocalSyncClient.schedulePersist.
+    if (autosaveTimer.current) return;
+    autosaveTimer.current = setTimeout(() => {
+      // Cleared before the run, not after: runAutosave awaits a request, and leaving
+      // the handle set would swallow every edit made while it was in flight instead
+      // of arming the next interval.
+      autosaveTimer.current = null;
+      void runAutosave();
+    }, AUTOSAVE_THROTTLE_MS);
   }, [projectId, runAutosave, setSaveStatus, snapshotCurrent]);
 
   const handleSceneChange = useCallback(
@@ -208,16 +237,44 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
     [currentFileIdRef, draftRef, scheduleAutosave, setDocContent, setDraft],
   );
 
+  // The two end-of-session signals, which do different things on purpose.
+  //
+  // visibilitychange -> hidden is the only one that fires when a tab is closed
+  // from the mobile tab switcher or the browser is killed from the app switcher,
+  // and with a 15 s interval instead of 2.5 s the window it covers is six times
+  // wider. It runs the ordinary save: the page survives a tab switch, so the
+  // response lands and the scene-delta bookkeeping stays in step with the server.
+  //
+  // pagehide is the last resort and cannot read a response, so it posts a full
+  // snapshot outside the queue and drops the delta baseline (see below).
+  useEffect(() => {
+    function flushOnHide() {
+      if (document.visibilityState !== "hidden") return;
+      if (!isSignedInRef.current || !dirtyRef.current) return;
+      cancelPendingAutosave();
+      snapshotRef.current ??= snapshotCurrent();
+      void runAutosave();
+    }
+    document.addEventListener("visibilitychange", flushOnHide);
+    return () => document.removeEventListener("visibilitychange", flushOnHide);
+  }, [cancelPendingAutosave, runAutosave, snapshotCurrent]);
+
   useEffect(() => {
     function flush() {
       const file = activeFileRef.current;
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // Deliberately not through the queue: this fires on `pagehide`, where the
-      // page may not live long enough to run another microtask. A direct
-      // `keepalive` fetch is handed to the browser to finish after teardown.
-      // `fields=meta` because nothing is left alive to read the response.
+      // Deliberately not through the queue: this fires on pagehide, where the page
+      // may not live long enough to run another microtask. A direct keepalive fetch
+      // is handed to the browser to finish after teardown. fields=meta because
+      // nothing is left alive to read the response.
+      //
+      // A full scene, never a delta, and the baseline is dropped: the response
+      // carrying the new sceneRev is never read, so a page restored from bfcache
+      // would otherwise send its next delta against a revision the server has
+      // already moved past.
+      resetSceneDelta(snapshot.file.id);
       void fetch(
         `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${snapshot.file.id}?fields=meta`,
         {
@@ -253,7 +310,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
         const snapshot = snapshotRef.current ?? snapshotCurrent();
         if (snapshot) void saveSnapshot(snapshot);
       }
-      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+      cancelPendingAutosave();
       snapshotRef.current = null;
       sceneRef.current = type === "diagram" ? scene : null;
       contentRef.current = type === "doc" ? content : "";
@@ -265,7 +322,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
   );
 
   const clearAutosave = useCallback(() => {
-    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    cancelPendingAutosave();
     snapshotRef.current = null;
   }, []);
   const invalidateFileAutosave = useCallback((fileId: string) => {

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -4,7 +4,7 @@ import { env } from "@OpenDiagram/env/web";
 import { saveGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
 import { writeLocalScene } from "@/lib/local-scene";
 import { queueProjectFilePatch } from "@/lib/project-file-sync";
-import { resetSceneDelta } from "@/lib/scene-delta";
+import { encodeScene, resetSceneDelta } from "@/lib/scene-delta";
 import { type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import {
@@ -257,17 +257,22 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
 
   // Outside the queue and keepalive, because pagehide may not survive another
   // microtask. Duplicates the hidden flush when both fire, on purpose: dirtyRef is
-  // the only honest "it landed" signal, and suppressing on anything cheaper drops
-  // saves that were merely queued or that failed.
+  // the only honest "it landed" signal, and gating on anything cheaper drops saves
+  // that were merely queued behind an in-flight request, or that failed.
   useEffect(() => {
     function flush() {
       const file = activeFileRef.current;
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // Whole scene, and the baseline goes first: nothing here reads the sceneRev
-      // back, so a page restored from bfcache would otherwise delta against a
-      // revision the server has moved past.
+      // Encoded before the baseline is dropped, so a navigation that also ran the
+      // hidden flush duplicates a ~2 kB delta rather than a 70 kB scene. Both carry
+      // the same base, so whichever lands second is a 409 that writes nothing.
+      // The baseline goes after, because nothing here reads the new sceneRev back.
+      const scene =
+        snapshot.file.type === "diagram"
+          ? encodeScene(snapshot.file.id, snapshot.scene).wire
+          : undefined;
       resetSceneDelta(snapshot.file.id);
       void fetch(
         `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${snapshot.file.id}?fields=meta`,
@@ -277,7 +282,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
           keepalive: true,
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            scene: snapshot.file.type === "diagram" ? snapshot.scene : undefined,
+            scene,
             content: snapshot.file.type === "doc" ? snapshot.content : undefined,
           }),
         },

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspacePersistence.ts
@@ -4,7 +4,7 @@ import { env } from "@OpenDiagram/env/web";
 import { saveGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
 import { writeLocalScene } from "@/lib/local-scene";
 import { queueProjectFilePatch } from "@/lib/project-file-sync";
-import { resetSceneDelta } from "@/lib/scene-delta";
+import { encodeScene, resetSceneDelta } from "@/lib/scene-delta";
 import { type SavedProjectFile } from "@/lib/projects-client";
 import type { WorkspaceSidebarFile } from "@/lib/workspace-layout-store";
 import {
@@ -265,12 +265,16 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
       if (!isSignedInRef.current || !dirtyRef.current || !file) return;
       const snapshot = snapshotCurrent();
       if (!snapshot) return;
-      // Whole scene, never a delta, and that is not an oversight. This is the only
-      // write with no follow-up, so it cannot be revision-gated: an autosave that
-      // commits between this encode and its arrival would leave the beacon 409ing
-      // with nothing alive to retry it, silently stranding the newest edit on the
-      // device. Unconditional costs ~70 kB once per unload, which is not the
-      // traffic this file exists to reduce.
+      // Unguarded delta, which is the only shape this path can use. A whole scene
+      // does not fit: keepalive bodies share a 64 KiB quota and our scenes average
+      // 70 kB, so the fetch is rejected before it leaves, and `void` swallows it.
+      // A guarded delta would 409 whenever an autosave commits first, with nothing
+      // alive to read the response or retry. So: small enough to send, and
+      // unconditional. https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+      const scene =
+        snapshot.file.type === "diagram"
+          ? encodeScene(snapshot.file.id, snapshot.scene, { guarded: false }).wire
+          : undefined;
       resetSceneDelta(snapshot.file.id);
       void fetch(
         `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${snapshot.file.id}?fields=meta`,
@@ -280,7 +284,7 @@ export function useWorkspacePersistence(options: UseWorkspacePersistenceOptions)
           keepalive: true,
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            scene: snapshot.file.type === "diagram" ? snapshot.scene : undefined,
+            scene,
             content: snapshot.file.type === "doc" ? snapshot.content : undefined,
           }),
         },

--- a/apps/web/src/lib/project-file-sync.ts
+++ b/apps/web/src/lib/project-file-sync.ts
@@ -8,26 +8,24 @@ import {
  * The one path every file PATCH takes, so a file is never written twice at once.
  *
  * A single diagram turn used to put three independent PATCHes on the wire against
- * the same row, from three callers that did not know about each other:
- * `use-diagram-canvas` writing `spec` once per `draw_diagram` call,
- * `use-diagram-chat` writing the whole chat history on finish, and the canvas
- * autosave writing `scene` because applying the diagram changed the canvas. Each
- * one costs four database round trips inside a transaction, and they raced -- the
- * autosave had a single-flight guard but the other two bypassed it entirely.
+ * the same row: use-diagram-canvas writing spec per draw_diagram call,
+ * use-diagram-chat writing chat history on finish, and canvas autosave writing
+ * scene because applying the diagram changed the canvas. Each cost four db round
+ * trips inside a transaction, and they raced (autosave had single-flight but the
+ * other two bypassed it).
  *
- * Here they coalesce. While a request for a file is in flight, further patches
- * merge into one pending object and go out together when it lands, so a burst
- * collapses to a single write instead of three. Patches touch disjoint columns in
- * the common case (`spec` vs `history` vs `scene`), and where they do overlap the
- * later value wins, which is the same last-writer-wins rule the local-first canvas
- * already runs on.
+ * Here they coalesce. While a request is in flight, further patches merge into one
+ * pending object and go out together, so a burst collapses to one write instead of
+ * three. Patches touch disjoint columns in the common case (spec vs history vs
+ * scene), and where they overlap the later value wins (last-writer-wins, same as
+ * the local-first canvas).
  *
- * Keyed by file id alone, not by project. A file id is a UUID and belongs to
- * exactly one project, so two projects cannot collide on one key.
+ * Keyed by file id alone, not by project. A file id is a UUID, belongs to exactly
+ * one project, so two projects cannot collide on one key.
  *
  * Every writer of the LARGE columns goes through here: autosave, manual Save, the
- * agent's `spec` and chat-history writes. Rename still calls `updateProjectFile`
- * directly on purpose -- `name` is a column no other writer touches.
+ * agent's spec and chat-history writes. Rename calls updateProjectFile directly
+ * on purpose; name is a column no other writer touches.
  */
 
 type PendingWrite = {
@@ -54,11 +52,11 @@ function createPending(projectId: string, fields: "full" | "meta"): PendingWrite
 }
 
 /**
- * Queue a patch for `fileId`, returning the response the write eventually gets.
+ * Queue a patch for fileId, returning the response the write eventually gets.
  *
- * Callers that were merged into one request all receive the same response object.
- * That is correct: it is the state of the row after their write, which is what
- * each of them asked for.
+ * Callers merged into one request all receive the same response object. That is
+ * correct: it is the state of the row after their write, which is what each of
+ * them asked for.
  */
 export function queueProjectFilePatch(
   projectId: string,
@@ -72,7 +70,7 @@ export function queueProjectFilePatch(
 
   Object.assign(entry.patch, patch);
   // One caller needing the content back forces the whole merged request to full.
-  // Downgrading would hand that caller a response with no `content` to read.
+  // Downgrading would hand that caller a response with no content to read.
   if (fields === "full") entry.fields = "full";
 
   if (!inFlight.has(fileId)) void drain(fileId);
@@ -83,8 +81,8 @@ async function drain(fileId: string): Promise<void> {
   if (inFlight.has(fileId)) return;
   inFlight.add(fileId);
   try {
-    // A loop rather than recursion: patches queued *while* a request is in flight
-    // must go out after it, and this picks them up without a second entry point.
+    // A loop, not recursion: patches queued while a request is in flight must go
+    // out after it, and this picks them up without a second entry point.
     for (;;) {
       const entry = pending.get(fileId);
       if (!entry) return;
@@ -103,11 +101,10 @@ async function drain(fileId: string): Promise<void> {
 }
 
 /**
- * Drop a queued write for a file that is being deleted.
- *
- * Without this, a file removed while its autosave was still queued would be
- * recreated-in-spirit by a PATCH landing after the DELETE -- which 404s, surfacing
- * a save error for a file the user deliberately threw away.
+ * Drop a queued write for a file that is being deleted. Without this, a file
+ * removed while its autosave was still queued would be recreated-in-spirit by a
+ * PATCH landing after the DELETE, which 404s and surfaces a save error for a file
+ * the user deliberately threw away.
  */
 export function cancelQueuedProjectFilePatch(fileId: string): void {
   const entry = pending.get(fileId);

--- a/apps/web/src/lib/projects-client/files.ts
+++ b/apps/web/src/lib/projects-client/files.ts
@@ -1,4 +1,5 @@
 import { env } from "@OpenDiagram/env/web";
+import { encodeScene, resetSceneDelta, seedSceneDelta } from "@/lib/scene-delta";
 import { readProjectResponse } from "./http";
 import type { CreateProjectFileInput, SavedProjectFile, UpdateProjectFileInput } from "./types";
 
@@ -18,6 +19,9 @@ export async function getProjectFile(projectId: string, fileId: string): Promise
   );
   const data = await readProjectResponse(response);
   if (!response.ok) throw new Error(data?.error ?? "Could not load project file.");
+  // The one place that sees a whole server-side scene, so the one place that can
+  // seed the delta baseline for the next save.
+  seedSceneDelta(fileId, data.file?.scene, data.file?.sceneRev);
   return data.file;
 }
 
@@ -40,12 +44,25 @@ export async function updateProjectFile(
   projectId: string,
   fileId: string,
   input: UpdateProjectFileInput,
-  // `meta` asks the server to leave the content columns out of the response. Use
-  // it from any caller that ignores the return value beyond `updatedAt` -- the
-  // full form ships the scene back down on every autosave. Callers that do
-  // `setActiveFile(updated)` must stay on "full" or they will blank the editor.
+  // meta asks the server to leave the content columns out of the response. Use it
+  // from any caller that ignores the return value beyond updatedAt; the full form
+  // ships the scene back down on every autosave. Callers that do
+  // setActiveFile(updated) must stay on full or they will blank the editor.
   fields: "full" | "meta" = "full",
 ): Promise<SavedProjectFile> {
+  return sendProjectFileUpdate(projectId, fileId, input, fields, true);
+}
+
+async function sendProjectFileUpdate(
+  projectId: string,
+  fileId: string,
+  input: UpdateProjectFileInput,
+  fields: "full" | "meta",
+  mayRetry: boolean,
+): Promise<SavedProjectFile> {
+  // A whole scene goes out as a delta of the elements whose version moved, when
+  // the server's revision is known.
+  const encoded = input.scene !== undefined ? encodeScene(fileId, input.scene) : null;
   const query = fields === "meta" ? "?fields=meta" : "";
   const response = await fetch(
     `${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${projectId}/files/${fileId}${query}`,
@@ -53,11 +70,22 @@ export async function updateProjectFile(
       method: "PATCH",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
+      body: JSON.stringify(encoded ? { ...input, scene: encoded.wire } : input),
     },
   );
+
+  // Delta built against a revision the server has moved past (another tab or
+  // device wrote in between). Drop the baseline so the retry carries the whole
+  // scene (last-writer-wins). Retry once: a second 409 means something is writing
+  // faster than we can respond, and looping is worse than surfacing it.
+  if (response.status === 409 && mayRetry) {
+    resetSceneDelta(fileId);
+    return sendProjectFileUpdate(projectId, fileId, input, fields, false);
+  }
+
   const data = await readProjectResponse(response);
   if (!response.ok) throw new Error(data?.error ?? "Could not save project file.");
+  encoded?.commit(data.file?.sceneRev);
   return data.file;
 }
 

--- a/apps/web/src/lib/projects-client/files.ts
+++ b/apps/web/src/lib/projects-client/files.ts
@@ -50,16 +50,6 @@ export async function updateProjectFile(
   // setActiveFile(updated) must stay on full or they will blank the editor.
   fields: "full" | "meta" = "full",
 ): Promise<SavedProjectFile> {
-  return sendProjectFileUpdate(projectId, fileId, input, fields, true);
-}
-
-async function sendProjectFileUpdate(
-  projectId: string,
-  fileId: string,
-  input: UpdateProjectFileInput,
-  fields: "full" | "meta",
-  mayRetry: boolean,
-): Promise<SavedProjectFile> {
   // A whole scene goes out as a delta of the elements whose version moved, when
   // the server's revision is known.
   const encoded = input.scene !== undefined ? encodeScene(fileId, input.scene) : null;
@@ -75,13 +65,15 @@ async function sendProjectFileUpdate(
   );
 
   // Delta built against a revision the server has moved past (another tab or
-  // device wrote in between). Drop the baseline so the retry carries the whole
-  // scene (last-writer-wins). Retry once: a second 409 means something is writing
-  // faster than we can respond, and looping is worse than surfacing it.
-  if (response.status === 409 && mayRetry) {
-    resetSceneDelta(fileId);
-    return sendProjectFileUpdate(projectId, fileId, input, fields, false);
-  }
+  // device wrote in between). Drop the baseline so the next save carries a whole
+  // scene, then let the failure surface.
+  //
+  // Deliberately no retry here. Replaying `input` would push a snapshot that is
+  // now older than what the server holds, unconditionally, and that is a write
+  // ordered by arrival rather than by edit. The caller's copy stays dirty in
+  // IndexedDB, so the next scheduled save resends from current state, which is
+  // the only layer that still knows what current state is.
+  if (response.status === 409) resetSceneDelta(fileId);
 
   const data = await readProjectResponse(response);
   if (!response.ok) throw new Error(data?.error ?? "Could not save project file.");

--- a/apps/web/src/lib/projects-client/types.ts
+++ b/apps/web/src/lib/projects-client/types.ts
@@ -34,6 +34,8 @@ export type SavedProjectFile = {
   spec?: RepositoryDocProvenance | unknown;
   content?: unknown;
   history?: unknown[];
+  /** Revision of the stored scene. Only what `lib/scene-delta.ts` reads it for. */
+  sceneRev?: number | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/apps/web/src/lib/scene-delta.ts
+++ b/apps/web/src/lib/scene-delta.ts
@@ -106,7 +106,7 @@ export function resetSceneDelta(fileId: string): void {
 export function encodeScene(
   fileId: string,
   scene: unknown,
-  { guarded = true }: { guarded?: boolean } = {},
+  { withBase = true }: { withBase?: boolean } = {},
 ): EncodedScene {
   const elements = readElements(scene);
   const baseline = baselines.get(fileId);
@@ -155,9 +155,10 @@ export function encodeScene(
 
   return {
     wire: {
-      // null asks the server to merge without checking the revision. Only the
-      // unload beacon does that, because a 409 there has no reader and no retry.
-      base: guarded ? baseline.rev : null,
+      // null asks the server to merge onto its current revision rather than the
+      // one held here. Only the unload beacon does that, because a 409 there has
+      // no reader and no retry. The write stays guarded either way.
+      base: withBase ? baseline.rev : null,
       changed,
       // ~1 kB of viewport and theme, replaced wholesale by the server. Not worth
       // diffing.

--- a/apps/web/src/lib/scene-delta.ts
+++ b/apps/web/src/lib/scene-delta.ts
@@ -103,7 +103,11 @@ export function resetSceneDelta(fileId: string): void {
   baselines.delete(fileId);
 }
 
-export function encodeScene(fileId: string, scene: unknown): EncodedScene {
+export function encodeScene(
+  fileId: string,
+  scene: unknown,
+  { guarded = true }: { guarded?: boolean } = {},
+): EncodedScene {
   const elements = readElements(scene);
   const baseline = baselines.get(fileId);
 
@@ -151,7 +155,9 @@ export function encodeScene(fileId: string, scene: unknown): EncodedScene {
 
   return {
     wire: {
-      base: baseline.rev,
+      // null asks the server to merge without checking the revision. Only the
+      // unload beacon does that, because a 409 there has no reader and no retry.
+      base: guarded ? baseline.rev : null,
       changed,
       // ~1 kB of viewport and theme, replaced wholesale by the server. Not worth
       // diffing.

--- a/apps/web/src/lib/scene-delta.ts
+++ b/apps/web/src/lib/scene-delta.ts
@@ -21,8 +21,8 @@
 
 type Baseline = {
   rev: number;
-  /** Element id to the version the server is known to hold. */
-  versions: Map<string, number>;
+  /** Element id to the stamp of the value the server is known to hold. */
+  stamps: Map<string, string>;
   /** Ids of binary blobs already uploaded, so they are sent exactly once. */
   fileIds: Set<string>;
 };
@@ -44,14 +44,32 @@ function readElements(scene: unknown): unknown[] | null {
   return Array.isArray(elements) ? elements : null;
 }
 
-function versionsOf(elements: readonly unknown[]): Map<string, number> {
-  const versions = new Map<string, number>();
+// Not version alone: it is a local counter, so two devices editing the same
+// element from the same base both reach n+1 for different content, and comparing
+// counters would call the local value unchanged and drop it. versionNonce is
+// random per mutation, which is why upstream reconciliation tie-breaks on it.
+function stampOf(element: unknown): string {
+  const { version, versionNonce } = element as { version?: unknown; versionNonce?: unknown };
+  return `${version ?? 0}:${versionNonce ?? 0}`;
+}
+
+function stampsOf(elements: readonly unknown[]): Map<string, string> {
+  const stamps = new Map<string, string>();
   for (const element of elements) {
     if (!element || typeof element !== "object") continue;
-    const { id, version } = element as { id?: unknown; version?: unknown };
-    if (typeof id === "string") versions.set(id, typeof version === "number" ? version : 0);
+    const { id } = element as { id?: unknown };
+    if (typeof id === "string") stamps.set(id, stampOf(element));
   }
-  return versions;
+  return stamps;
+}
+
+// A scene without fractional indices carries z-order in array position alone, so
+// reordering it produces no changed elements and the server would keep its old
+// order. Only reachable for scenes stored before restoreElements assigned indices.
+function hasFractionalIndices(elements: readonly unknown[]): boolean {
+  return elements.every(
+    (element) => typeof (element as { index?: unknown } | null)?.index === "string",
+  );
 }
 
 function fileIdsOf(scene: unknown): Set<string> {
@@ -75,7 +93,7 @@ export function seedSceneDelta(fileId: string, scene: unknown, sceneRev: unknown
   }
   baselines.set(fileId, {
     rev: sceneRev,
-    versions: versionsOf(elements),
+    stamps: stampsOf(elements),
     fileIds: fileIdsOf(scene),
   });
 }
@@ -98,21 +116,24 @@ export function encodeScene(fileId: string, scene: unknown): EncodedScene {
     }
     baselines.set(fileId, {
       rev: sceneRev,
-      versions: versionsOf(elements),
+      stamps: stampsOf(elements),
       fileIds: fileIdsOf(scene),
     });
   };
 
   // No baseline, or a scene we can't reason about (legacy skeletons payload,
-  // explicit null clearing the column, first save after file opens). Send the
-  // whole thing and let the response establish the baseline.
-  if (baseline === undefined || elements === null) return { wire: scene, commit };
+  // explicit null clearing the column, first save after file opens, or elements
+  // with no fractional index to carry z-order). Send the whole thing and let the
+  // response establish the baseline.
+  if (baseline === undefined || elements === null || !hasFractionalIndices(elements)) {
+    return { wire: scene, commit };
+  }
 
   const changed = elements.filter((element) => {
     if (!element || typeof element !== "object") return true;
-    const { id, version } = element as { id?: unknown; version?: unknown };
+    const { id } = element as { id?: unknown };
     if (typeof id !== "string") return true;
-    return baseline.versions.get(id) !== (typeof version === "number" ? version : 0);
+    return baseline.stamps.get(id) !== stampOf(element);
   });
 
   // Deletions need no separate channel: Excalidraw keeps removed elements in the

--- a/apps/web/src/lib/scene-delta.ts
+++ b/apps/web/src/lib/scene-delta.ts
@@ -1,0 +1,142 @@
+/**
+ * Encoding a canvas save as a delta instead of a whole scene.
+ *
+ * The autosave used to PUT its entire scene on every write (70 kB avg, 248 kB
+ * max, several times a minute). Almost none of it changed. Excalidraw stamps every
+ * element with a version that moves on any mutation, including z-order changes
+ * (which travel as the fractional index on the element, not array position), so
+ * "what changed" is a comparison, not a diff algorithm.
+ *
+ * Lives at the transport boundary on purpose. project-file-sync.ts coalesces
+ * concurrent writers with Object.assign, which is right for whole scenes (later one
+ * wins) and wrong for two deltas (their changed-element sets would need unioning
+ * against the older base). Encoding here, one layer below the queue, leaves that
+ * merge correct: the queue still passes whole scenes around and only the request
+ * on the wire is a delta.
+ *
+ * The queue also makes the baseline safe to hold in a module-level map: it
+ * guarantees at most one in-flight request per file, so no two encodes race for
+ * one entry.
+ */
+
+type Baseline = {
+  rev: number;
+  /** Element id to the version the server is known to hold. */
+  versions: Map<string, number>;
+  /** Ids of binary blobs already uploaded, so they are sent exactly once. */
+  fileIds: Set<string>;
+};
+
+const baselines = new Map<string, Baseline>();
+
+type Scene = { elements?: unknown; appState?: unknown; files?: unknown };
+
+export type EncodedScene = {
+  /** What to send as scene: either a whole scene or { base, changed, ... }. */
+  wire: unknown;
+  /** Call with the response's sceneRev once the write lands. */
+  commit: (sceneRev: number | null | undefined) => void;
+};
+
+function readElements(scene: unknown): unknown[] | null {
+  if (!scene || typeof scene !== "object") return null;
+  const elements = (scene as Scene).elements;
+  return Array.isArray(elements) ? elements : null;
+}
+
+function versionsOf(elements: readonly unknown[]): Map<string, number> {
+  const versions = new Map<string, number>();
+  for (const element of elements) {
+    if (!element || typeof element !== "object") continue;
+    const { id, version } = element as { id?: unknown; version?: unknown };
+    if (typeof id === "string") versions.set(id, typeof version === "number" ? version : 0);
+  }
+  return versions;
+}
+
+function fileIdsOf(scene: unknown): Set<string> {
+  const files = (scene as Scene | null)?.files;
+  if (!files || typeof files !== "object") return new Set();
+  return new Set(Object.keys(files as Record<string, unknown>));
+}
+
+/**
+ * Record what the server holds so the next save can be a delta.
+ *
+ * Called with the response of a full file read. Seeding from the server's copy is
+ * what makes this correct when a dirty local copy wins the reconcile on open:
+ * the delta then carries exactly the elements the local copy changed.
+ */
+export function seedSceneDelta(fileId: string, scene: unknown, sceneRev: unknown): void {
+  const elements = readElements(scene);
+  if (elements === null || typeof sceneRev !== "number") {
+    baselines.delete(fileId);
+    return;
+  }
+  baselines.set(fileId, {
+    rev: sceneRev,
+    versions: versionsOf(elements),
+    fileIds: fileIdsOf(scene),
+  });
+}
+
+/** Force the next save of this file to carry a whole scene. */
+export function resetSceneDelta(fileId: string): void {
+  baselines.delete(fileId);
+}
+
+export function encodeScene(fileId: string, scene: unknown): EncodedScene {
+  const elements = readElements(scene);
+  const baseline = baselines.get(fileId);
+
+  const commit = (sceneRev: number | null | undefined) => {
+    // No revision back means the content row was not written. Dropping the
+    // baseline costs one full scene and cannot desync.
+    if (typeof sceneRev !== "number" || elements === null) {
+      baselines.delete(fileId);
+      return;
+    }
+    baselines.set(fileId, {
+      rev: sceneRev,
+      versions: versionsOf(elements),
+      fileIds: fileIdsOf(scene),
+    });
+  };
+
+  // No baseline, or a scene we can't reason about (legacy skeletons payload,
+  // explicit null clearing the column, first save after file opens). Send the
+  // whole thing and let the response establish the baseline.
+  if (baseline === undefined || elements === null) return { wire: scene, commit };
+
+  const changed = elements.filter((element) => {
+    if (!element || typeof element !== "object") return true;
+    const { id, version } = element as { id?: unknown; version?: unknown };
+    if (typeof id !== "string") return true;
+    return baseline.versions.get(id) !== (typeof version === "number" ? version : 0);
+  });
+
+  // Deletions need no separate channel: Excalidraw keeps removed elements in the
+  // array as isDeleted: true with a bumped version, picked up above like any other
+  // change.
+  const files = (scene as Scene).files;
+  const newFiles =
+    files && typeof files === "object"
+      ? Object.fromEntries(
+          Object.entries(files as Record<string, unknown>).filter(
+            ([id]) => !baseline.fileIds.has(id),
+          ),
+        )
+      : undefined;
+
+  return {
+    wire: {
+      base: baseline.rev,
+      changed,
+      // ~1 kB of viewport and theme, replaced wholesale by the server. Not worth
+      // diffing.
+      appState: (scene as Scene).appState,
+      ...(newFiles && Object.keys(newFiles).length > 0 ? { files: newFiles } : {}),
+    },
+    commit,
+  };
+}

--- a/packages/db/src/migrations/0005_add_scene_rev.sql
+++ b/packages/db/src/migrations/0005_add_scene_rev.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "project_file_content" ADD COLUMN "scene_rev" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/0005_snapshot.json
+++ b/packages/db/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1767 @@
+{
+  "id": "d6d255c3-176a-44c2-a2b1-a9dae8484aac",
+  "prevId": "8cebfc9f-20f0-4f36-a711-cad1b52aa1fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ai_provider": {
+      "name": "user_ai_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ai_provider_user_provider_idx": {
+          "name": "user_ai_provider_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ai_provider_one_default_per_user_idx": {
+          "name": "user_ai_provider_one_default_per_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_ai_provider\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ai_provider_user_id_user_id_fk": {
+          "name": "user_ai_provider_user_id_user_id_fk",
+          "tableFrom": "user_ai_provider",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_credits": {
+          "name": "monthly_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_grant": {
+          "name": "signup_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_cap": {
+          "name": "daily_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_daily_cap_multiplier": {
+          "name": "ip_daily_cap_multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cost_ceiling_cents": {
+          "name": "cost_ceiling_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "burst_per_minute": {
+          "name": "burst_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "plan_monthly_credits_check": {
+          "name": "plan_monthly_credits_check",
+          "value": "\"plan\".\"monthly_credits\" >= 0"
+        },
+        "plan_signup_grant_check": {
+          "name": "plan_signup_grant_check",
+          "value": "\"plan\".\"signup_grant\" >= 0"
+        },
+        "plan_daily_cap_check": {
+          "name": "plan_daily_cap_check",
+          "value": "\"plan\".\"daily_cap\" >= 0"
+        },
+        "plan_ip_daily_cap_multiplier_check": {
+          "name": "plan_ip_daily_cap_multiplier_check",
+          "value": "\"plan\".\"ip_daily_cap_multiplier\" >= 1"
+        },
+        "plan_cost_ceiling_cents_check": {
+          "name": "plan_cost_ceiling_cents_check",
+          "value": "\"plan\".\"cost_ceiling_cents\" >= 0"
+        },
+        "plan_burst_per_minute_check": {
+          "name": "plan_burst_per_minute_check",
+          "value": "\"plan\".\"burst_per_minute\" >= 1"
+        },
+        "plan_max_concurrent_check": {
+          "name": "plan_max_concurrent_check",
+          "value": "\"plan\".\"max_concurrent\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dodo_customer_id": {
+          "name": "dodo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_amount_cents": {
+          "name": "recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_user_status_idx": {
+          "name": "subscription_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_plan_id_idx": {
+          "name": "subscription_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscription_plan_id_plan_id_fk": {
+          "name": "subscription_plan_id_plan_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "plan",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "subscription_status_check": {
+          "name": "subscription_status_check",
+          "value": "\"subscription\".\"status\" IN ('pending', 'active', 'on_hold', 'cancelled', 'failed', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_micros": {
+          "name": "cost_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_ledger_actor_window_idx": {
+          "name": "usage_ledger_actor_window_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"status\" <> 'released'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_ledger_turn_idx": {
+          "name": "usage_ledger_turn_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"turn_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_ledger_plan_id_idx": {
+          "name": "usage_ledger_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_ledger_plan_id_plan_id_fk": {
+          "name": "usage_ledger_plan_id_plan_id_fk",
+          "tableFrom": "usage_ledger",
+          "tableTo": "plan",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "usage_ledger_cost_micros_check": {
+          "name": "usage_ledger_cost_micros_check",
+          "value": "\"usage_ledger\".\"cost_micros\" >= 0"
+        },
+        "usage_ledger_status_check": {
+          "name": "usage_ledger_status_check",
+          "value": "\"usage_ledger\".\"status\" IN ('reserved', 'settled', 'refunded', 'released')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creation_usage": {
+      "name": "creation_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'month'"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creation_usage_actor_window_idx": {
+          "name": "creation_usage_actor_window_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "creation_usage_actor_type_check": {
+          "name": "creation_usage_actor_type_check",
+          "value": "\"creation_usage\".\"actor_type\" IN ('guest', 'user')"
+        },
+        "creation_usage_period_check": {
+          "name": "creation_usage_period_check",
+          "value": "\"creation_usage\".\"period\" IN ('month', 'day')"
+        },
+        "creation_usage_count_check": {
+          "name": "creation_usage_count_check",
+          "value": "\"creation_usage\".\"count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_event": {
+      "name": "webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_event_created_at_idx": {
+          "name": "webhook_event_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_status": {
+          "name": "generation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_userId_idx": {
+          "name": "project_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_user_id_user_id_fk": {
+          "name": "project_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file": {
+      "name": "project_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_projectId_idx": {
+          "name": "project_file_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_project_id_fk": {
+          "name": "project_file_project_id_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_file_type_check": {
+          "name": "project_file_type_check",
+          "value": "\"project_file\".\"type\" IN ('diagram', 'doc')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_file_content": {
+      "name": "project_file_content",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene_rev": {
+          "name": "scene_rev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history": {
+          "name": "history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_file_content_file_id_project_file_id_fk": {
+          "name": "project_file_content_file_id_project_file_id_fk",
+          "tableFrom": "project_file_content",
+          "tableTo": "project_file",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file_thread": {
+      "name": "project_file_thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_thread_file_updated_idx": {
+          "name": "project_file_thread_file_updated_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_thread_project_updated_idx": {
+          "name": "project_file_thread_project_updated_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_thread_project_id_project_id_fk": {
+          "name": "project_file_thread_project_id_project_id_fk",
+          "tableFrom": "project_file_thread",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_file_thread_file_id_project_file_id_fk": {
+          "name": "project_file_thread_file_id_project_file_id_fk",
+          "tableFrom": "project_file_thread",
+          "tableTo": "project_file",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file_message": {
+      "name": "project_file_message",
+      "schema": "",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_message_thread_client_idx": {
+          "name": "project_file_message_thread_client_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_message_thread_id_project_file_thread_id_fk": {
+          "name": "project_file_message_thread_id_project_file_thread_id_fk",
+          "tableFrom": "project_file_message",
+          "tableTo": "project_file_thread",
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_file_message_thread_id_seq_pk": {
+          "name": "project_file_message_thread_id_seq_pk",
+          "columns": ["thread_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_file_message_role_check": {
+          "name": "project_file_message_role_check",
+          "value": "\"project_file_message\".\"role\" IN ('user', 'assistant')"
+        },
+        "project_file_message_seq_check": {
+          "name": "project_file_message_seq_check",
+          "value": "\"project_file_message\".\"seq\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_import_job": {
+      "name": "github_import_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_import_job_user_id_idx": {
+          "name": "github_import_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_import_job_project_id_idx": {
+          "name": "github_import_job_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_import_job_user_repo_partial_idx": {
+          "name": "github_import_job_user_repo_partial_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status NOT IN ('done', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_import_job_user_id_user_id_fk": {
+          "name": "github_import_job_user_id_user_id_fk",
+          "tableFrom": "github_import_job",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_import_job_project_id_project_id_fk": {
+          "name": "github_import_job_project_id_project_id_fk",
+          "tableFrom": "github_import_job",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785907911720,
       "tag": "0004_goofy_sleepwalker",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786002230091,
+      "tag": "0005_add_scene_rev",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/projects/project-file-content.ts
+++ b/packages/db/src/schema/projects/project-file-content.ts
@@ -1,12 +1,12 @@
 import { relations } from "drizzle-orm";
-import { jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import { integer, jsonb, pgTable, text } from "drizzle-orm/pg-core";
 
 import { projectFile } from "./project-file";
 
 /**
- * The heavy half of a file, split 1:1 off `project_file`. scene/spec/content/
+ * The heavy half of a file, split 1:1 off project_file. scene/spec/content/
  * history run to hundreds of KB; keeping them here means the dashboard tree and
- * file list (which never touch these columns) don't share pages with TOASTed
+ * file list (which never touch these columns) do not share pages with TOASTed
  * data. One row per file, cascade-deleted with it.
  */
 export const projectFileContent = pgTable("project_file_content", {
@@ -14,6 +14,16 @@ export const projectFileContent = pgTable("project_file_content", {
     .primaryKey()
     .references(() => projectFile.id, { onDelete: "cascade" }),
   scene: jsonb("scene"),
+  /**
+   * Bumped by every write that touches scene, and by nothing else. The canvas
+   * sends element deltas against the revision it last had acknowledged, so this
+   * is what lets the server tell "these changes apply to what I hold" from "this
+   * client is working off a scene someone else has since replaced" and answer 409.
+   *
+   * Deliberately not updatedAt: that moves for a rename or a chat write too,
+   * which would invalidate a perfectly good delta baseline.
+   */
+  sceneRev: integer("scene_rev").notNull().default(0),
   spec: jsonb("spec"),
   content: jsonb("content"),
   history: jsonb("history")


### PR DESCRIPTION
## What does this PR do?

Cuts `PATCH /api/projects/:projectId/files/:fileId` from ~40% of all API traffic down to roughly a sixth of its request count, and shrinks each request from ~70 kB to a couple of kB.

Sentry, last 24h production: PATCH was 197 calls against ~500 total API calls. It is the only endpoint that scales with how hard someone draws; everything else is bounded by navigation.

Three changes:

**1. Throttle instead of debounce.** `AUTOSAVE_DELAY_MS = 2500` was a trailing debounce, so every pause in drawing longer than 2.5s became a request. A debounce does not bound the rate under intermittent input. Now a 15s throttle, which does. Affordable because IndexedDB (not the server) is what makes an edit durable. Excalidraw ships a 20s interval backed only by localStorage; we additionally reconcile a dirty local copy on open. Adds their `isSavePaused` behaviour (hidden tab replicates nothing) and a `visibilitychange -> hidden` flush, which is the only signal that fires when a tab is closed from the mobile tab switcher.

**2. Element deltas.** Every save shipped the whole scene (70 kB avg, 248 kB max), almost none of it changed. Excalidraw stamps each element with a `version` that moves on any mutation, so "what changed" is a comparison, not a diff algorithm. A new `scene_rev` column carries the revision a delta is built against; a mismatch answers 409 and the client resends a whole scene. Binary blobs now upload once instead of on every save.

**3. Single-statement write.** `BEGIN / UPDATE / upsert / COMMIT` becomes one data-modifying CTE. Four round trips to one, or two when a delta has to read the current scene to merge it.

## Type of change

- [x] Chore / refactor / CI
- [ ] Bug fix
- [ ] New feature
- [ ] Diagram engine / layout change (`packages/harness`)
- [ ] Documentation


## Checklist

- [x] `just check` passes
- [x] `just types` passes
- [x] If I touched `packages/harness`, `bun test` passes in that package (not touched)
- [x] I restarted `dev:server` when verifying harness changes (n/a)
- [x] Changes are scoped to the issue - no unrelated refactors

## Notes for review

- **Migration `0005_add_scene_rev` is already applied to production.** Additive   `ADD COLUMN ... DEFAULT 0 NOT NULL`, catalog-only on PG17, no table rewrite.  **This buys wire bytes, not database time.** Postgres rewrites the whole TOASTed  jsonb either way. That only goes away when `scene` moves to R2; the TODO in   `apps/server/src/lib/scene-delta.ts` marks the seam.
- Z-order needs no separate channel: it rides the fractional `index` on the element,   and `zindex.ts` reorders through `syncMovedIndices -> mutateElement`, which bumps  `version`. Deletions likewise, via `isDeleted` tombstones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut canvas save traffic by throttling autosave, sending element deltas, and using a single-statement DB write. PATCH requests drop to roughly one-sixth, payloads shrink from ~70 kB to a few kB, and conflict handling is tightened (including a guarded unload beacon).

- **Refactors**
  - Autosave is a 15s throttle. Saves pause when the tab is hidden, flush on visibilitychange, and drain at most one snapshot per interval. Durability comes from IndexedDB.
  - Scene saves send only changed elements. The server merges deltas and guards with a scene revision; on mismatch it returns 409 and the client resends a full scene. The hidden flush uses a delta; the pagehide keepalive now sends a delta with a null base, merged onto the row’s current revision and guarded, to fit keepalive size limits.
  - Replaced multi-step transactions with one data-modifying CTE, cutting DB round trips from four to one (two when a merge reads current state). Ownership checks are preserved.
  - Added `scene_rev` integer column to `project_file_content` (DEFAULT 0, NOT NULL). Already applied to production.

- **Bug Fixes**
  - `scene_rev` now advances on every scene write (including repo generation/import) to prevent stale baselines; mismatches answer 409.
  - Fixed a potential deadlock by matching lock order (touch `project_file` before content) in generation.
  - Element identity uses `versionNonce` alongside `version`, so concurrent edits don’t get dropped.
  - Edge cases: files without fractional indices send full scenes for z-order changes; delta requests are strictly discriminated; empty-content responses include `sceneRev`; the unload beacon’s merge is guarded against the row it read and won’t create content rows from deltas.

<sup>Written for commit 84e72e8c57477dfbba18f08783fa70e20b4f76f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

