### PR TITLE
perf: cut redundant API traffic and make the DB pool survivable

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -93,12 +93,10 @@ app.use(
 app.get("/", (c) => c.text("OK"));
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-// Resolves the Better Auth session once and attributes the wide event from it.
-// Everything downstream -- `requireAuth`, the quota actor, the BYOK lookup in
-// /api/diagram/chat -- reads that same result via `getRequestSession`, so a
-// request costs one session resolution rather than the two or three it used to.
-app.use("*", resolveSession);
-
+// Ahead of `resolveSession` deliberately: cors answers a preflight with 204 and
+// never calls next(), so an OPTIONS stops resolving a session it cannot use.
+// `maxAge` because every PATCH was buying its own preflight -- 8 of them in one
+// drawing session against a single file. Chrome caps the value at 7200s anyway.
 app.use(
   "/*",
   cors({
@@ -107,8 +105,15 @@ app.use(
     allowHeaders: ["Content-Type", "Authorization"],
     exposeHeaders: ["X-CreationQuota-Limit", "X-CreationQuota-Used", "X-CreationQuota-Remaining"],
     credentials: true,
+    maxAge: 86400,
   }),
 );
+
+// Resolves the Better Auth session once and attributes the wide event from it.
+// Everything downstream -- `requireAuth`, the quota actor, the BYOK lookup in
+// /api/diagram/chat -- reads that same result via `getRequestSession`, so a
+// request costs one session resolution rather than the two or three it used to.
+app.use("*", resolveSession);
 
 app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 app.route("/api/diagram", diagramRoute);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -79,7 +79,11 @@ app.use(
   evlog({
     drain: (ctx) => {
       fsDrain(ctx);
-      if (ctx.event.level === "warn" || ctx.event.level === "error") {
+      // On status too, not just level: a handler that answers 500 without throwing
+      // leaves the event at `info`, so the level gate alone never saw those.
+      const status = ctx.event.status;
+      const failed = typeof status === "number" && status >= 500;
+      if (ctx.event.level === "warn" || ctx.event.level === "error" || failed) {
         // Defer into the chain so a synchronous throw is caught too, rather
         // than escaping as an uncaught error.
         void Promise.resolve()

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -79,8 +79,10 @@ app.use(
   evlog({
     drain: (ctx) => {
       fsDrain(ctx);
-      // On status too, not just level: a handler that answers 500 without throwing
-      // leaves the event at `info`, so the level gate alone never saw those.
+      // On status too, not just level. evlog 2.22.4 does not derive level from the
+      // response: 404, 500, and even a route that throws all arrive here at `info`,
+      // so the level gate on its own forwarded no failed request at all. Verified
+      // against `evlog/hono` directly, because the opposite is easy to assume.
       const status = ctx.event.status;
       const failed = typeof status === "number" && status >= 500;
       if (ctx.event.level === "warn" || ctx.event.level === "error" || failed) {

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
+import { clearAiSettingsCache } from "@/lib/settings-client";
 import { GuestWelcomeDialog } from "@/components/auth/guest-welcome-dialog";
 import { CheckoutReturn } from "@/components/billing/checkout-return";
 import { DashboardDialogs } from "@/components/dashboard/dashboard-page/DashboardDialogs";
@@ -28,6 +29,7 @@ export default function DashboardPage() {
     setSignOutPending(true);
     try {
       await authClient.signOut();
+      clearAiSettingsCache();
       data.resetSavedProjects();
       setSignedOutDialogOpen(true);
     } finally {

--- a/apps/web/src/components/settings/settings-profile.tsx
+++ b/apps/web/src/components/settings/settings-profile.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowRight, LogOut } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
+import { clearAiSettingsCache } from "@/lib/settings-client";
 import { assetUrl } from "@/lib/site";
 import { getInitials } from "@/components/dashboard/dashboard-page/utils";
 import { Button } from "@/components/ui/button";
@@ -52,6 +53,7 @@ export function SettingsProfileCard() {
     setSignOutPending(true);
     try {
       await authClient.signOut();
+      clearAiSettingsCache();
       router.push("/dashboard");
       router.refresh();
     } finally {

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceLayoutController.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceLayoutController.ts
@@ -6,6 +6,7 @@ import { authClient } from "@/lib/auth-client";
 import type { StoredChatMessage } from "@/lib/chat-history";
 import { deleteGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
 import type { SavedProject, SavedProjectFile } from "@/lib/projects-client";
+import { clearAiSettingsCache } from "@/lib/settings-client";
 import { useWorkspaceLayoutStore } from "@/lib/workspace-layout-store";
 import type { SaveStatus } from "./helpers";
 import { useWorkspacePaneResize } from "./useWorkspacePaneResize";
@@ -164,6 +165,7 @@ export function useWorkspaceLayoutController() {
 
   async function signOut() {
     await authClient.signOut();
+    clearAiSettingsCache();
   }
 
   function continueAsGuest() {

--- a/apps/web/src/lib/settings-client.ts
+++ b/apps/web/src/lib/settings-client.ts
@@ -48,10 +48,41 @@ async function readError(response: Response, fallback: string): Promise<string> 
   return body?.error ?? fallback;
 }
 
+/**
+ * Cached because `AgentInputPanel` and `use-ai-chat-panel-controller` each fetch
+ * this on mount, so one dashboard-then-workspace visit made four identical calls.
+ *
+ * Per-account: the payload carries `keyLast4`, so sign-out MUST clear it. Nothing
+ * here reloads the page, and module state would otherwise outlive the account.
+ */
+let settingsCache: { settings: AiSettings; fetchedAt: number } | null = null;
+let settingsRequest: Promise<AiSettings> | null = null;
+const SETTINGS_TTL_MS = 30_000;
+
+export function clearAiSettingsCache(): void {
+  settingsCache = null;
+  settingsRequest = null;
+}
+
 export async function getAiSettings(): Promise<AiSettings> {
-  const response = await fetch(`${BASE}/providers`, { credentials: "include" });
-  if (!response.ok) throw new Error(await readError(response, "Failed to load Settings."));
-  return response.json();
+  const cached = settingsCache;
+  if (cached && Date.now() - cached.fetchedAt < SETTINGS_TTL_MS) return cached.settings;
+  if (settingsRequest) return settingsRequest;
+
+  const request = (async () => {
+    const response = await fetch(`${BASE}/providers`, { credentials: "include" });
+    if (!response.ok) throw new Error(await readError(response, "Failed to load Settings."));
+    const settings = (await response.json()) as AiSettings;
+    settingsCache = { settings, fetchedAt: Date.now() };
+    return settings;
+  })();
+  settingsRequest = request;
+
+  try {
+    return await request;
+  } finally {
+    if (settingsRequest === request) settingsRequest = null;
+  }
 }
 
 export async function connectProvider(input: {
@@ -66,6 +97,7 @@ export async function connectProvider(input: {
     body: JSON.stringify(input),
   });
   if (!response.ok) throw new Error(await readError(response, "Could not connect provider."));
+  clearAiSettingsCache();
 }
 
 export async function updateProvider(
@@ -79,6 +111,7 @@ export async function updateProvider(
     body: JSON.stringify(input),
   });
   if (!response.ok) throw new Error(await readError(response, "Could not update provider."));
+  clearAiSettingsCache();
 }
 
 export function providerModelOptions(settings: AiSettings): ProviderModelOption[] {
@@ -113,4 +146,5 @@ export async function disconnectProvider(id: string): Promise<void> {
     credentials: "include",
   });
   if (!response.ok) throw new Error(await readError(response, "Could not disconnect provider."));
+  clearAiSettingsCache();
 }

--- a/apps/web/src/lib/settings-client.ts
+++ b/apps/web/src/lib/settings-client.ts
@@ -57,9 +57,11 @@ async function readError(response: Response, fallback: string): Promise<string> 
  */
 let settingsCache: { settings: AiSettings; fetchedAt: number } | null = null;
 let settingsRequest: Promise<AiSettings> | null = null;
+let generation = 0;
 const SETTINGS_TTL_MS = 30_000;
 
 export function clearAiSettingsCache(): void {
+  generation += 1;
   settingsCache = null;
   settingsRequest = null;
 }
@@ -69,11 +71,15 @@ export async function getAiSettings(): Promise<AiSettings> {
   if (cached && Date.now() - cached.fetchedAt < SETTINGS_TTL_MS) return cached.settings;
   if (settingsRequest) return settingsRequest;
 
+  const started = generation;
   const request = (async () => {
     const response = await fetch(`${BASE}/providers`, { credentials: "include" });
     if (!response.ok) throw new Error(await readError(response, "Failed to load Settings."));
     const settings = (await response.json()) as AiSettings;
-    settingsCache = { settings, fetchedAt: Date.now() };
+    // Clearing only drops the pending promise; this response is still in flight and
+    // would otherwise refill the cache it was meant to evict. A sign-out mid-fetch
+    // is exactly the case that leaks, so a bumped generation must not be cached.
+    if (started === generation) settingsCache = { settings, fetchedAt: Date.now() };
     return settings;
   })();
   settingsRequest = request;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,9 +9,15 @@ export { and, desc, eq, exists, inArray, lt, ne, notInArray, or, sql } from "dri
 export function createDb() {
   const pool = new Pool({
     connectionString: env.DATABASE_URL,
-    // `pg` defaults this to 0, which means queue forever: one PATCH sat 66s
-    // against the Supavisor pooler before the socket died.
+    // Both default to off, so a request had no deadline of any kind.
     connectionTimeoutMillis: 10_000,
+    // The one that bounds the 66s PATCH: that hang was a query on an already
+    // checked-out client, which `connectionTimeoutMillis` does not cover. Client
+    // side (`pg/lib/client.js` arms a plain timer), so unlike `statement_timeout`
+    // it still fires when the pooler has dropped the socket and nothing replies.
+    // Ceiling on hangs, not a target: the slowest real statement we have measured
+    // is the 8.7s scene upsert.
+    query_timeout: 30_000,
   });
 
   // Drizzle attaches no 'error' listener of its own, and pg-pool re-emits an idle

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,12 +1,27 @@
 import { env } from "@OpenDiagram/env/server";
 import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
 
 import * as schema from "./schema";
 
 export { and, desc, eq, exists, inArray, lt, ne, notInArray, or, sql } from "drizzle-orm";
 
 export function createDb() {
-  return drizzle(env.DATABASE_URL, { schema });
+  const pool = new Pool({
+    connectionString: env.DATABASE_URL,
+    // `pg` defaults this to 0, which means queue forever: one PATCH sat 66s
+    // against the Supavisor pooler before the socket died.
+    connectionTimeoutMillis: 10_000,
+  });
+
+  // Drizzle attaches no 'error' listener of its own, and pg-pool re-emits an idle
+  // client's error on the pool. Unheard, that is fatal in Node, so one connection
+  // dropped by the pooler would take the server down instead of one request.
+  pool.on("error", (error) => {
+    console.error("[db] idle client error", error);
+  });
+
+  return drizzle(pool, { schema });
 }
 
 export const db = createDb();


### PR DESCRIPTION
Three browser sessions of the same workflow (dashboard, quota, new file, AI diagram, manual edits, back to dashboard) were recorded through `.evlog` and audited for redundant calls.

## Results

| | before | after |
|---|---|---|
| requests per session | 42 | 28 |
| CORS preflights | 14 | 5 |
| `OPTIONS files/:fileId` | 8 | 1 (for 4 PATCHes) |
| `GET ai/providers` | 4 | 2, three minutes apart |

The remaining two provider calls are a genuine dashboard revisit past the 30s TTL, not duplicates. The after run did strictly more work than the before run (it included the return to the dashboard) and still used a third fewer requests.

## What changed

**CORS preflights.** `resolveSession` was registered ahead of `cors()`, so every OPTIONS resolved a Better Auth session it could never use. Hono's cors answers a preflight with 204 without calling `next()`, so ordering it first skips that entirely. Adding `maxAge` stops the browser re-preflighting every single write.

**AI settings fetch.** Two unrelated mount effects each called `getAiSettings` with no cache between them. Now a 30s cache plus a shared in-flight promise. The payload carries `keyLast4`, so it is account scoped and both sign-out paths clear
it; neither reloads the page, so module state would otherwise outlive the account.

**5xx observability.** The Sentry drain gated on log level alone, and a handler that answers 500 without throwing leaves the event at `info`. A PATCH that burned 66s never reached Sentry Logs. That is why the first audit pass looked clean.

**DB pool.** `drizzle(env.DATABASE_URL)` created a pool with no options, inheriting `connectionTimeoutMillis: 0` (queue forever). Verified with a throwaway probe: at the default a blackholed connect was still hanging at 8s; at 3s it fails in 3004ms.

More seriously, drizzle attaches no `error` listener and pg-pool re-emits an idle client's error on the pool. An unheard `error` is fatal in Node, so one connection dropped by the pooler would have taken the whole server down rather than costing a single request. Confirmed by probe: `listenerCount('error')` is 0 both before and after `drizzle(pool)`, and an unheard emit throws.

## What this does not fix

The 500 itself looks pooler side. `auth.resolvedIn` was 15004ms, matching Supavisor's own 15000ms `db_call` timeout, and the same "Connection terminated unexpectedly" against a transaction-mode pooler is reported in supabase/supavisor#344 with no clean resolution. This PR bounds the failure and keeps it survivable; it does not remove it. The 500 did not reproduce in the third run.

`statement_timeout` was deliberately left out. The 66s incident was a connect hang, not a statement hang, and any number picked now would be a guess.

## Still open, not in this PR

- `GET threads/active` still fires twice on workspace mount. Ruled out as a  shared cause with the providers pair; it is local to the chat panel mount.
- Excalidraw "Fractional indices invariant has been compromised" when an AI  diagram lands on a canvas that already holds one. Predates this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts redundant requests and CORS preflights, and hardens the DB pool so pooler hiccups don’t crash the server. Sessions now use ~33% fewer requests (42 → 28) and preflights drop from 14 → 5.

- **Performance**
  - Register `hono/cors` before session resolution and add preflight `maxAge` to avoid resolving sessions on `OPTIONS`.
  - Collapse duplicate AI settings fetches with a 30s cache and shared in-flight request; clear on all sign-out paths and provider changes; a generation guard blocks post-sign-out refills.

- **Reliability & Observability**
  - Send 5xx responses to the Sentry drain even when handlers don’t throw; gate on response status since `evlog` does not derive level from the response.
  - Use a `pg` `Pool` with `connectionTimeoutMillis: 10000`, `query_timeout: 30000`, and an `error` listener, then pass it to `drizzle-orm` to avoid fatal idle-client errors and bound connect and in-flight query hangs.

<sup>Written for commit b28eae6d302f9607e4db851b51ff1afeeb0d8c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

