### PR TITLE
feat(byok): per-request model selection and key rotation

### DIFF
--- a/apps/server/src/lib/ai-grant.ts
+++ b/apps/server/src/lib/ai-grant.ts
@@ -14,7 +14,7 @@
  */
 import type { AuditableLogger } from "evlog";
 import type { Context } from "hono";
-import { resolveModel } from "./ai-provider/resolve";
+import { ModelSelectionError, resolveModel, type ModelSelection } from "./ai-provider/resolve";
 import { enforceAiQuota, quotaErrorResponse } from "./quota";
 import type { AiCallOptions, AiUsage } from "./repo-ai";
 
@@ -39,18 +39,23 @@ export type AiGrant = {
  *
  * `meter: false` resolves a model but takes no credit — for work already paid for
  * on a previous request, such as resuming an in-flight repo generation.
+ *
+ * `selection` overrides the user's saved default for this call only.
  */
 export async function takeAiGrant<E extends { Variables: { log: AuditableLogger } }>(
   c: Context<E>,
   userId: string,
   route: string,
-  options: { meter?: boolean } = {},
+  options: { meter?: boolean; selection?: ModelSelection } = {},
 ): Promise<AiGrant | Response> {
   const log = c.get("log");
   let resolved: Awaited<ReturnType<typeof resolveModel>>;
   try {
-    resolved = await resolveModel(userId);
+    resolved = await resolveModel(userId, options.selection);
   } catch (error) {
+    if (error instanceof ModelSelectionError) {
+      return c.json({ error: error.message, code: "model_unavailable" }, 400);
+    }
     log.error("Failed to resolve BYOK model", { error });
     return c.json({ error: "Your saved AI provider key could not be used. Check Settings." }, 502);
   }

--- a/apps/server/src/lib/ai-provider/resolve.ts
+++ b/apps/server/src/lib/ai-provider/resolve.ts
@@ -61,19 +61,29 @@ async function resolveUserModel(
   }
 
   const provider = getProvider(row.provider);
-  if (!provider) return null;
+  if (!provider) {
+    if (providerId) throw new ModelSelectionError("That provider is no longer supported.");
+    return null;
+  }
 
   if (modelId && !isKnownModel(provider, modelId)) {
     throw new ModelSelectionError(`${provider.label} does not offer that model.`);
   }
   const chosenModelId = modelId ?? row.modelId;
 
-  // If the key can't be decrypted (e.g. BYOK_ENCRYPTION_KEY unset/rotated),
-  // fall back to the platform model rather than failing the whole request.
+  // If the key can't be decrypted (e.g. BYOK_ENCRYPTION_KEY unset/rotated) the
+  // caller who named no provider falls back to the platform model rather than
+  // failing the whole request. One who named this row does not: they would be
+  // billed quota for a model they did not pick.
   let apiKey: string;
   try {
     apiKey = decryptSecret(row.encryptedApiKey, { userId, provider: row.provider });
   } catch {
+    if (providerId) {
+      throw new ModelSelectionError(
+        `Your saved ${provider.label} key could not be used. Reconnect it in Settings.`,
+      );
+    }
     return null;
   }
 

--- a/apps/server/src/lib/ai-provider/resolve.ts
+++ b/apps/server/src/lib/ai-provider/resolve.ts
@@ -1,7 +1,8 @@
 /**
- * Picks the AI model for a request: a signed-in user's default BYOK provider if
- * they have one, otherwise the platform Gemini key. BYOK usage is the user's own
- * spend, so it doesn't count against the platform creation quota.
+ * Picks the AI model for a request: the one the caller asked for, else the
+ * signed-in user's default BYOK provider, else the platform Gemini key. BYOK
+ * usage is the user's own spend, so it doesn't count against the platform
+ * creation quota.
  */
 import { createGoogle } from "@ai-sdk/google";
 import { and, db, eq } from "@OpenDiagram/db";
@@ -10,7 +11,7 @@ import { env } from "@OpenDiagram/env/server";
 import type { LanguageModel } from "ai";
 import { createCachingFetch } from "../agent/cache";
 import { decryptSecret } from "./encrypt";
-import { getProvider } from "./registry";
+import { getProvider, isKnownModel } from "./registry";
 
 const PLATFORM_MODEL = "gemini-2.5-flash";
 
@@ -23,17 +24,53 @@ export type ResolvedModel = {
   countsAgainstQuota: boolean;
 };
 
-/** The signed-in user's default BYOK model, or null if they have none configured. */
-async function resolveUserModel(userId: string): Promise<ResolvedModel | null> {
+/**
+ * One request's override of the user's saved default.
+ *
+ * `providerId` is the `user_ai_provider` ROW id that `GET /api/ai-settings/providers`
+ * hands the client, NOT the provider kind ("openai"). A user holds one row per kind
+ * and the row is what carries the key, so the row id is the only thing that
+ * identifies a runnable choice.
+ */
+export type ModelSelection = { providerId?: string | null; modelId?: string | null };
+
+/**
+ * A selection the caller cannot run. Separate from a decrypt failure because this
+ * one is the client's fault and is worth a 400. Degrading to the platform model
+ * instead would silently answer on a model the user did not pick and bill it to
+ * their creation quota.
+ */
+export class ModelSelectionError extends Error {}
+
+/** The user's BYOK model for this request, or null if they have no usable key. */
+async function resolveUserModel(
+  userId: string,
+  { providerId, modelId }: ModelSelection,
+): Promise<ResolvedModel | null> {
   const [row] = await db
     .select()
     .from(userAiProvider)
-    .where(and(eq(userAiProvider.userId, userId), eq(userAiProvider.isDefault, true)))
+    .where(
+      and(
+        eq(userAiProvider.userId, userId),
+        // Scoping every lookup by userId is what makes an unguessed row id
+        // someone else's problem: a stolen id resolves to no row, not their key.
+        providerId ? eq(userAiProvider.id, providerId) : eq(userAiProvider.isDefault, true),
+      ),
+    )
     .limit(1);
-  if (!row) return null;
+  if (!row) {
+    if (providerId) throw new ModelSelectionError("That provider is not connected.");
+    return null;
+  }
 
   const provider = getProvider(row.provider);
   if (!provider) return null;
+
+  if (modelId && !isKnownModel(provider, modelId)) {
+    throw new ModelSelectionError(`${provider.label} does not offer that model.`);
+  }
+  const chosenModelId = modelId ?? row.modelId;
 
   // If the key can't be decrypted (e.g. BYOK_ENCRYPTION_KEY unset/rotated),
   // fall back to the platform model rather than failing the whole request.
@@ -45,10 +82,10 @@ async function resolveUserModel(userId: string): Promise<ResolvedModel | null> {
   }
 
   return {
-    model: provider.createModel(apiKey, row.modelId),
+    model: provider.createModel(apiKey, chosenModelId),
     source: "byok",
     provider: row.provider,
-    modelId: row.modelId,
+    modelId: chosenModelId,
     countsAgainstQuota: false,
   };
 }
@@ -77,11 +114,18 @@ function resolvePlatformModel(): ResolvedModel | null {
 
 /**
  * Resolve the model for a (maybe-anonymous) request: BYOK first for signed-in
- * users, else platform. Returns null only when neither is available.
+ * users, else platform. Returns null only when neither is available, and throws
+ * `ModelSelectionError` when `selection` names something the user cannot run.
+ *
+ * An anonymous caller's `selection` is ignored rather than rejected: the options
+ * are built from the caller's own connected providers, so they never had one.
  */
-export async function resolveModel(userId?: string | null): Promise<ResolvedModel | null> {
+export async function resolveModel(
+  userId?: string | null,
+  selection: ModelSelection = {},
+): Promise<ResolvedModel | null> {
   if (userId) {
-    const byok = await resolveUserModel(userId);
+    const byok = await resolveUserModel(userId, selection);
     if (byok) return byok;
   }
   return resolvePlatformModel();

--- a/apps/server/src/lib/ai-provider/resolve.ts
+++ b/apps/server/src/lib/ai-provider/resolve.ts
@@ -25,20 +25,15 @@ export type ResolvedModel = {
 };
 
 /**
- * One request's override of the user's saved default.
- *
- * `providerId` is the `user_ai_provider` ROW id that `GET /api/ai-settings/providers`
- * hands the client, NOT the provider kind ("openai"). A user holds one row per kind
- * and the row is what carries the key, so the row id is the only thing that
- * identifies a runnable choice.
+ * One request's override of the user's saved default. `providerId` is the
+ * `user_ai_provider` ROW id, NOT the provider kind ("openai").
  */
 export type ModelSelection = { providerId?: string | null; modelId?: string | null };
 
 /**
- * A selection the caller cannot run. Separate from a decrypt failure because this
- * one is the client's fault and is worth a 400. Degrading to the platform model
- * instead would silently answer on a model the user did not pick and bill it to
- * their creation quota.
+ * A selection the caller cannot run, which routes turn into a 400. Degrading to
+ * the platform model instead would answer on a model the user did not pick and
+ * bill it to their creation quota.
  */
 export class ModelSelectionError extends Error {}
 
@@ -53,8 +48,9 @@ async function resolveUserModel(
     .where(
       and(
         eq(userAiProvider.userId, userId),
-        // Scoping every lookup by userId is what makes an unguessed row id
-        // someone else's problem: a stolen id resolves to no row, not their key.
+        // Never drop the userId predicate and match on the row id alone, even
+        // though it is the primary key: that is what stops one user naming
+        // another user's row and running on their key.
         providerId ? eq(userAiProvider.id, providerId) : eq(userAiProvider.isDefault, true),
       ),
     )

--- a/apps/server/src/routes/ai-settings.ts
+++ b/apps/server/src/routes/ai-settings.ts
@@ -45,7 +45,16 @@ function publicProvider(row: typeof userAiProvider.$inferSelect) {
   };
 }
 
-/** Confirm a key actually works before we store it (cheap 1-token call). */
+/**
+ * Confirm a key actually works before we store it (cheap 1-token call).
+ *
+ * The timeout is load-bearing. A provider that accepts the connection and then
+ * never answers held this request open for 258s in testing, and because the
+ * dialog disables its own Cancel while saving, the only way out was a reload.
+ * Successful checks measured 5.6s and 7.7s against OpenRouter.
+ *
+ * https://github.com/vercel/ai/blob/main/content/docs/03-ai-sdk-core/25-settings.mdx
+ */
 async function assertKeyWorks(provider: string, apiKey: string, modelId: string) {
   const def = getProvider(provider);
   if (!def) throw new Error("Unknown provider.");
@@ -55,6 +64,7 @@ async function assertKeyWorks(provider: string, apiKey: string, modelId: string)
     telemetry: aiTelemetry("byok-key-check"),
     maxOutputTokens: 8,
     maxRetries: 0,
+    abortSignal: AbortSignal.timeout(20_000),
   });
 }
 
@@ -209,6 +219,10 @@ function keyErrorMessage(error: unknown): string {
   const msg = error instanceof Error ? error.message.toLowerCase() : "";
   if (msg.includes("401") || msg.includes("unauthorized") || msg.includes("invalid api key")) {
     return "That API key was rejected by the provider.";
+  }
+  // Says nothing about the key, so it must not read as a rejection.
+  if (msg.includes("abort") || msg.includes("timed out") || msg.includes("timeout")) {
+    return "The provider did not respond in time. Try again in a moment.";
   }
   return "Could not verify that key. Check it and try again.";
 }

--- a/apps/server/src/routes/diagram.ts
+++ b/apps/server/src/routes/diagram.ts
@@ -15,7 +15,7 @@ import { buildCanvasContext, buildSystemPrompt } from "../lib/agent/prompt";
 import { askUserTool, createDrawDiagramTool, drawDiagramInputSchema } from "../lib/agent/tools";
 import { enforceAiQuota, quotaErrorResponse } from "../lib/quota";
 import { getRequestSession } from "../lib/session";
-import { resolveModel } from "../lib/ai-provider/resolve";
+import { ModelSelectionError, resolveModel } from "../lib/ai-provider/resolve";
 import { LLM_MAX_RETRIES } from "../lib/repo-ai";
 import { aiTelemetry } from "../lib/telemetry";
 
@@ -33,6 +33,11 @@ const chatRequestSchema = z.object({
     .max(MAX_PROMPT_DIAGRAMS)
     .optional(),
   theme: z.enum(["classic", "sketch"]).optional(),
+  // Run this one request on a specific BYOK row + model instead of the caller's
+  // saved default. Both are checked against the caller's own rows in
+  // `resolveModel`; matching the catalog is not enough to make them runnable.
+  providerId: z.string().min(1).max(64).optional(),
+  modelId: z.string().min(1).max(120).optional(),
 });
 
 // gemini-2.5-flash reliably mangles edge keys in draw_diagram calls (emits
@@ -102,7 +107,7 @@ diagramRoute.post("/chat", async (c) => {
   if (!parsed.success) {
     return c.json({ error: "Invalid request", issues: parsed.error.issues }, 400);
   }
-  const { messages, diagrams = [], theme: themeName = "sketch" } = parsed.data;
+  const { messages, providerId, modelId, diagrams = [], theme: themeName = "sketch" } = parsed.data;
 
   const tools = {
     ask_user: askUserTool,
@@ -136,8 +141,11 @@ diagramRoute.post("/chat", async (c) => {
   const userId = session?.user.id;
   let resolved: Awaited<ReturnType<typeof resolveModel>>;
   try {
-    resolved = await resolveModel(userId);
+    resolved = await resolveModel(userId, { providerId, modelId });
   } catch (error) {
+    if (error instanceof ModelSelectionError) {
+      return c.json({ error: error.message, code: "model_unavailable" }, 400);
+    }
     log.error("Failed to resolve BYOK model", { error });
     return c.json({ error: "Your saved AI provider key could not be used. Check Settings." }, 502);
   }

--- a/apps/server/src/routes/diagram.ts
+++ b/apps/server/src/routes/diagram.ts
@@ -33,9 +33,8 @@ const chatRequestSchema = z.object({
     .max(MAX_PROMPT_DIAGRAMS)
     .optional(),
   theme: z.enum(["classic", "sketch"]).optional(),
-  // Run this one request on a specific BYOK row + model instead of the caller's
-  // saved default. Both are checked against the caller's own rows in
-  // `resolveModel`; matching the catalog is not enough to make them runnable.
+  // Overrides the caller's saved default for this request only. Validated in
+  // `resolveModel` against their own rows, not here.
   providerId: z.string().min(1).max(64).optional(),
   modelId: z.string().min(1).max(120).optional(),
 });

--- a/apps/server/src/routes/projects/chat.ts
+++ b/apps/server/src/routes/projects/chat.ts
@@ -7,6 +7,9 @@ import type { AuthVariables } from "../../lib/require-auth";
 
 const chatSchema = z.object({
   message: z.string().min(1).max(4000),
+  // See `chatRequestSchema` in routes/diagram.ts, same per-request BYOK override.
+  providerId: z.string().min(1).max(64).optional(),
+  modelId: z.string().min(1).max(120).optional(),
 });
 
 export const chatRoute = new Hono<{ Variables: AuthVariables }>();
@@ -29,7 +32,9 @@ chatRoute.post("/:projectId/chat", async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  const grant = await takeAiGrant(c, userId, "project-chat");
+  const grant = await takeAiGrant(c, userId, "project-chat", {
+    selection: { providerId: parsed.data.providerId, modelId: parsed.data.modelId },
+  });
   if (grant instanceof Response) return grant;
 
   let answer: string;

--- a/apps/web/src/components/dashboard/dashboard-page/AgentInputPanel.tsx
+++ b/apps/web/src/components/dashboard/dashboard-page/AgentInputPanel.tsx
@@ -97,8 +97,8 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
     return [...groups.entries()];
   }, [providerOptions]);
 
-  // The pick travels to the workspace in the URL and from there into each chat
-  // request, so choosing a model writes nothing to the database.
+  // No write: the pick reaches the workspace through the URL, and the workspace
+  // sends it on every chat request.
   function handleProviderSelect(option: ProviderModelOption) {
     setProviderId(option.id);
     setProviderDialogOpen(false);

--- a/apps/web/src/components/dashboard/dashboard-page/AgentInputPanel.tsx
+++ b/apps/web/src/components/dashboard/dashboard-page/AgentInputPanel.tsx
@@ -3,7 +3,6 @@ import { Check, ChevronsUpDown, FileText, PenTool, Sparkles } from "lucide-react
 import {
   getAiSettings,
   providerModelOptions,
-  selectProviderModel,
   type ProviderModelOption,
 } from "@/lib/settings-client";
 import {
@@ -60,7 +59,6 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
   const [providerOptions, setProviderOptions] = useState<ProviderModelOption[]>([]);
   const [providerDialogOpen, setProviderDialogOpen] = useState(false);
   const [providerError, setProviderError] = useState<string | null>(null);
-  const [selectingProvider, setSelectingProvider] = useState(false);
   useEffect(() => setCtaIndex(Math.floor(Math.random() * agentCtas.length)), []);
   useEffect(() => {
     setProviderError(null);
@@ -99,21 +97,11 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
     return [...groups.entries()];
   }, [providerOptions]);
 
-  async function handleProviderSelect(option: ProviderModelOption) {
-    if (selectingProvider) return;
-
-    setSelectingProvider(true);
-    setProviderError(null);
-    try {
-      await selectProviderModel(option);
-      setProviderId(option.id);
-      setProviderDialogOpen(false);
-    } catch (cause) {
-      setProviderError(cause instanceof Error ? cause.message : "Could not select this provider.");
-      setProviderDialogOpen(false);
-    } finally {
-      setSelectingProvider(false);
-    }
+  // The pick travels to the workspace in the URL and from there into each chat
+  // request, so choosing a model writes nothing to the database.
+  function handleProviderSelect(option: ProviderModelOption) {
+    setProviderId(option.id);
+    setProviderDialogOpen(false);
   }
 
   return (
@@ -125,7 +113,7 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
         onSubmit={(event) => {
           event.preventDefault();
           const text = prompt.trim();
-          if (!text || creating || selectingProvider) return;
+          if (!text || creating) return;
 
           setProviderError(null);
           onSubmit({
@@ -174,7 +162,7 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
               type="button"
               variant="ghost"
               size="sm"
-              disabled={creating || selectingProvider || providerOptions.length === 0}
+              disabled={creating || providerOptions.length === 0}
               className="h-8 min-w-0 max-w-56 justify-start gap-1.5 rounded-[10px] px-2 text-[13px] font-semibold text-[#9ca3af]"
               aria-label="Choose AI provider model"
               onClick={() => setProviderDialogOpen(true)}
@@ -186,7 +174,7 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
             <Dialog
               open={providerDialogOpen}
               onOpenChange={(open) => {
-                if (!selectingProvider) setProviderDialogOpen(open);
+                setProviderDialogOpen(open);
               }}
             >
               <DialogContent className="max-w-2xl overflow-hidden p-0">
@@ -204,8 +192,7 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
                           <CommandItem
                             key={option.id}
                             value={option.label}
-                            disabled={selectingProvider}
-                            onSelect={() => void handleProviderSelect(option)}
+                            onSelect={() => handleProviderSelect(option)}
                             className="items-start gap-3 px-3 py-3"
                           >
                             <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
@@ -232,10 +219,10 @@ export function AgentInputPanel({ creating, onSubmit, signedIn }: AgentInputPane
             </Dialog>
             <button
               type="submit"
-              disabled={creating || selectingProvider || prompt.trim().length === 0}
+              disabled={creating || prompt.trim().length === 0}
               className="h-8 rounded-[10px] bg-od-ink px-4 text-[13px] font-semibold text-white transition hover:bg-[#2a2a2a] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {creating || selectingProvider ? "Creating..." : "Create"}
+              {creating ? "Creating..." : "Create"}
             </button>
           </div>
           {providerError && (

--- a/apps/web/src/components/settings/providers.tsx
+++ b/apps/web/src/components/settings/providers.tsx
@@ -276,7 +276,14 @@ function ConnectDialog({
   onConnected: () => Promise<void>;
 }) {
   const [apiKey, setApiKey] = useState("");
-  const [modelId, setModelId] = useState(connected?.modelId ?? provider?.models[0]?.id ?? "");
+  // Only seed from the saved row while the catalog still offers that model. A row
+  // written before a model was retired would otherwise leave the select blank and
+  // submit the retired id, which the server rejects, blocking the rotation.
+  const [modelId, setModelId] = useState(
+    (provider?.models.some((m) => m.id === connected?.modelId)
+      ? connected?.modelId
+      : provider?.models[0]?.id) ?? "",
+  );
   const [saving, setSaving] = useState(false);
 
   async function save() {

--- a/apps/web/src/components/settings/providers.tsx
+++ b/apps/web/src/components/settings/providers.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { Check, Loader2, Star, Trash2 } from "lucide-react";
+import { Check, KeyRound, Loader2, Star, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { assetUrl } from "@/lib/site";
 import {
@@ -112,6 +112,7 @@ export function Providers() {
       <ConnectDialog
         key={connecting?.id ?? "closed"}
         provider={connecting}
+        connected={connecting ? (connectedByProvider.get(connecting.id) ?? null) : null}
         onClose={() => setConnecting(null)}
         onConnected={refresh}
       />
@@ -232,6 +233,15 @@ function ProviderCard({
           <Button
             variant="outline"
             size="sm"
+            disabled={disabled || busy}
+            onClick={onConnect}
+            title="Replace API key"
+          >
+            <KeyRound className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
             disabled={busy}
             onClick={() => run(() => disconnectProvider(connected.id), "Disconnected.")}
             title="Disconnect"
@@ -248,17 +258,25 @@ function ProviderCard({
   );
 }
 
+/**
+ * Also the key-rotation dialog: `POST /providers` upserts on (userId, provider),
+ * so reconnecting an already-connected provider replaces its key in place and
+ * keeps the row, its id and its default flag. Seeding `modelId` from the saved
+ * row matters because that upsert writes whatever model this form submits.
+ */
 function ConnectDialog({
   provider,
+  connected,
   onClose,
   onConnected,
 }: {
   provider: CatalogProvider | null;
+  connected: ConnectedProvider | null;
   onClose: () => void;
   onConnected: () => Promise<void>;
 }) {
   const [apiKey, setApiKey] = useState("");
-  const [modelId, setModelId] = useState(provider?.models[0]?.id ?? "");
+  const [modelId, setModelId] = useState(connected?.modelId ?? provider?.models[0]?.id ?? "");
   const [saving, setSaving] = useState(false);
 
   async function save() {
@@ -266,7 +284,7 @@ function ConnectDialog({
     setSaving(true);
     try {
       await connectProvider({ provider: provider.id, apiKey: apiKey.trim(), modelId });
-      toast.success(`${provider.label} connected.`);
+      toast.success(connected ? `${provider.label} key replaced.` : `${provider.label} connected.`);
       await onConnected();
       onClose();
     } catch (error) {
@@ -284,11 +302,12 @@ function ConnectDialog({
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2.5">
                 <ProviderIcon providerId={provider.id} label={provider.label} />
-                Connect {provider.label}
+                {connected ? `Replace ${provider.label} key` : `Connect ${provider.label}`}
               </DialogTitle>
               <DialogDescription>
-                Your key is validated, then encrypted before it&apos;s stored. It&apos;s never shown
-                again.
+                {connected
+                  ? `Replaces the key ending ${connected.keyLast4}. The new one is validated first, so a bad key leaves the old one in place.`
+                  : "Your key is validated, then encrypted before it's stored. It's never shown again."}
               </DialogDescription>
             </DialogHeader>
 
@@ -334,7 +353,7 @@ function ConnectDialog({
               </Button>
               <Button onClick={save} disabled={saving || apiKey.trim().length < 8}>
                 {saving && <Loader2 className="size-4 animate-spin" />}
-                Validate & connect
+                {connected ? "Validate & replace" : "Validate & connect"}
               </Button>
             </DialogFooter>
           </>

--- a/apps/web/src/components/whiteboard/ai-chat-panel/use-ai-chat-panel-controller.ts
+++ b/apps/web/src/components/whiteboard/ai-chat-panel/use-ai-chat-panel-controller.ts
@@ -11,12 +11,7 @@ import {
   storedChatMessageToUIMessage,
   type StoredChatMessage,
 } from "@/lib/chat-history";
-import {
-  getAiSettings,
-  providerModelOptions,
-  selectProviderModel,
-  type ProviderModelOption,
-} from "@/lib/settings-client";
+import { getAiSettings, providerModelOptions } from "@/lib/settings-client";
 import { isLikelyDiagramRequest } from "@/lib/workspace-agents";
 import type { AiProviderUsage } from "@/lib/ai-provider-usage";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
@@ -99,20 +94,14 @@ export function useAIChatPanelController({
     },
     [fileId, projectId],
   );
-  // True only between accepting a submit and the model actually starting, which
-  // is a gap the chat status cannot see. Gates the thread controls.
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [theme, setTheme] = useState<ThemeName>("sketch");
   const [providerUsage, setProviderUsage] = useState<AiProviderUsage | null>(null);
-  const [providerId, setProviderIdState] = useState(
+  // Picking a model is local state only. It rides along on the next request as
+  // `providerId`/`modelId`; the saved default is changed from Settings, not here.
+  const [providerId, setProviderId] = useState(
     initialProviderId && initialModelId ? `${initialProviderId}:${initialModelId}` : "platform",
   );
   const [providerOptions, setProviderOptions] = useState<AIChatProviderOption[]>([]);
-  const providerOptionsRef = useRef<ProviderModelOption[]>([]);
-  const providerUpdateRef = useRef<Promise<void>>(Promise.resolve());
-  const providerUpdateFailedRef = useRef(false);
-  const providerIdRef = useRef(providerId);
-  const providerRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (!projectId) return;
@@ -121,7 +110,6 @@ export function useAIChatPanelController({
       .then((settings) => {
         if (!active) return;
         const options = providerModelOptions(settings);
-        providerOptionsRef.current = options;
         setProviderOptions(options);
         const initialOption =
           initialProviderId && initialModelId
@@ -130,10 +118,9 @@ export function useAIChatPanelController({
                   option.providerId === initialProviderId && option.modelId === initialModelId,
               )
             : undefined;
-        const nextProviderId =
-          initialOption?.id ?? options.find((option) => option.isDefault)?.id ?? "platform";
-        providerIdRef.current = nextProviderId;
-        setProviderIdState(nextProviderId);
+        setProviderId(
+          initialOption?.id ?? options.find((option) => option.isDefault)?.id ?? "platform",
+        );
       })
       .catch(() => undefined);
     return () => {
@@ -142,35 +129,6 @@ export function useAIChatPanelController({
   }, [initialModelId, initialProviderId, projectId]);
 
   const selectedProvider = providerOptions.find((option) => option.id === providerId);
-
-  const setProviderId = useCallback(
-    (nextProviderId: string) => {
-      const option = providerOptionsRef.current.find(
-        (candidate) => candidate.id === nextProviderId,
-      );
-      if (!option) return;
-
-      const requestId = ++providerRequestIdRef.current;
-      const previousProviderId = providerIdRef.current;
-      providerIdRef.current = nextProviderId;
-      setProviderIdState(nextProviderId);
-      providerUpdateFailedRef.current = false;
-      const request = providerUpdateRef.current
-        .catch(() => undefined)
-        .then(() => selectProviderModel(option));
-      providerUpdateRef.current = request.catch(() => undefined);
-      void request.catch((cause) => {
-        if (requestId !== providerRequestIdRef.current) return;
-        providerUpdateFailedRef.current = true;
-        providerIdRef.current = previousProviderId;
-        setProviderIdState(previousProviderId);
-        onProviderError?.(
-          cause instanceof Error ? cause.message : "Could not select this provider.",
-        );
-      });
-    },
-    [onProviderError],
-  );
   const autoDiagramPrompt =
     activeFileType === "diagram"
       ? normalizedHistory.find((message) => message.role === "user")
@@ -251,18 +209,6 @@ export function useAIChatPanelController({
       const status = projectChat.status !== "ready" ? projectChat.status : diagramChat.status;
       if (!text || (status !== "ready" && status !== "error")) return;
 
-      // Held across the provider await below. Until `sendMessage` runs, neither
-      // chat's status has moved off `ready`, so the thread controls would still
-      // be live -- and a switch inside that window files this turn under the
-      // conversation the user moved to instead of the one they typed into.
-      setIsSubmitting(true);
-      try {
-        await providerUpdateRef.current;
-      } finally {
-        setIsSubmitting(false);
-      }
-      if (providerUpdateFailedRef.current) return;
-
       canvas.setApplyError(null);
       const pending = pendingAskUser(diagramChat.messages);
       if (pending) {
@@ -324,7 +270,7 @@ export function useAIChatPanelController({
       thread.startNewThread().catch((cause: unknown) => {
         onProviderError?.(cause instanceof Error ? cause.message : "Could not start a new chat.");
       }),
-    threadSwitching: thread.isSwitching || isSubmitting,
+    threadSwitching: thread.isSwitching,
     threads: thread.threads,
     applyError: canvas.applyError,
     conversationMessages,

--- a/apps/web/src/lib/settings-client.ts
+++ b/apps/web/src/lib/settings-client.ts
@@ -139,13 +139,6 @@ export function providerModelOptions(settings: AiSettings): ProviderModelOption[
   });
 }
 
-export async function selectProviderModel(option: ProviderModelOption): Promise<void> {
-  await updateProvider(option.providerId, {
-    modelId: option.modelId,
-    makeDefault: true,
-  });
-}
-
 export async function disconnectProvider(id: string): Promise<void> {
   const response = await fetch(`${BASE}/providers/${id}`, {
     method: "DELETE",


### PR DESCRIPTION
## What does this PR do?

The client already sent `providerId` and `modelId` on every chat request, but both server schemas dropped them. The only way to change model was a `PATCH /providers/:id` that flipped the user's saved default, which the composer fired on every pick behind a promise queue and an optimistic rollback.

`resolveModel` now takes a `ModelSelection`. Picking a model is local state and writes nothing. Settings gains a **Replace API key** action, which the server already supported via upsert but had no UI for once a provider was connected.

Closes the gap #43 was aiming at.

## Type of change

- [x] New feature
- [x] Bug fix

## Notes for review

- `providerId` is the `user_ai_provider` **row id**, not the provider kind. Every  lookup stays scoped by `userId`, so a row id belonging to someone else resolves  to no row.
- An unconnected provider or a model the provider does not offer raises   `ModelSelectionError` → 400. Falling back to the platform model there would  answer on a model the user did not pick and bill it to their creation quota.
- Behaviour change: the composer pick no longer survives a reload. The dropdown  reopens on whichever provider is `isDefault`. Defaults are set from Settings.
- Separate fix: `assertKeyWorks` had `maxRetries: 0` but no deadline. A provider that accepted the connection then went quiet held a request open for 258s,  measured. Now 20s, against successful checks of 5.6s and 7.7s.

## Checklist

- [x] `just check` passes
- [x] `just types` passes
- [x] Changes are scoped to the issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-request BYOK model selection and a “Replace API key” flow in Settings to simplify model picking and make failures explicit. Removes background PATCHes and avoids silent fallback to the platform model when the user picked a provider/model.

- **New Features**
  - Per-request override: `providerId` and `modelId` are accepted by `/diagram/chat` and `/projects/:projectId/chat`. Ownership and availability are validated; invalid picks return 400 with `code: "model_unavailable"`.
  - Local-only picker: the choice is local state and sent with each request; no writes. Defaults are set in Settings. A reload returns to the saved default.
  - Key rotation: new “Replace API key” in Settings. `POST /providers` upserts to safely swap keys in place, preserving the row and its default flag.

- **Bug Fixes**
  - Explicit picks that cannot run (unknown/foreign row, unsupported provider, undecryptable key, or unknown model) now return 400 `model_unavailable` instead of falling back to the platform model.
  - Settings reliability: provider key validation now times out after 20s with a clear timeout message, and the replace-key dialog seeds the saved `modelId` only if the catalog still offers it to avoid submitting retired models.

<sup>Written for commit 5b794a31874e0ac56765d216621be2846f855591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

