### PR TITLE
fix(server): keep pg external so db spans survive the bundle

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -29,6 +29,7 @@
     "elkjs": "^0.11.1",
     "evlog": "catalog:",
     "hono": "^4.8.2",
+    "pg": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
   format: "esm",
   outDir: "./dist",
   clean: true,
+  // Anything under noExternal drags its own deps into the bundle, and a bundled
+  // module is never loaded by specifier, so Sentry's preload hook cannot wrap it.
+  // That is why `pg` is a dependency of this app it never imports: tsdown
+  // externalizes package.json deps, which is the only reason `db` spans exist.
+  // https://github.com/getsentry/sentry-javascript/issues/14028
   noExternal: [/@OpenDiagram\/.*/],
 });

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   clean: true,
   // Anything under noExternal drags its own deps into the bundle, and a bundled
   // module is never loaded by specifier, so Sentry's preload hook cannot wrap it.
-  // That is why `pg` is a dependency of this app it never imports: tsdown
+  // That is why `pg` is a dependency of this app that it never imports: tsdown
   // externalizes package.json deps, which is the only reason `db` spans exist.
   // https://github.com/getsentry/sentry-javascript/issues/14028
   noExternal: [/@OpenDiagram\/.*/],

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
         "elkjs": "^0.11.1",
         "evlog": "catalog:",
         "hono": "^4.8.2",
+        "pg": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -188,7 +189,7 @@
         "@OpenDiagram/env": "workspace:*",
         "dotenv": "catalog:",
         "drizzle-orm": "catalog:",
-        "pg": "^8.17.1",
+        "pg": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -240,6 +241,7 @@
     "lucide-react": "^1.21.0",
     "motion": "^12.42.2",
     "next-themes": "^0.4.6",
+    "pg": "^8.22.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "sonner": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "evlog": "^2.19.2",
       "lodash.throttle": "^4.1.1",
       "lucide-react": "^1.21.0",
+      "pg": "^8.22.0",
       "motion": "^12.42.2",
       "next-themes": "^0.4.6",
       "react": "^19.2.7",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,7 +26,7 @@
     "@OpenDiagram/env": "workspace:*",
     "dotenv": "catalog:",
     "drizzle-orm": "catalog:",
-    "pg": "^8.17.1",
+    "pg": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
Declares `pg` as a dependency of `apps/server` and moves it to the workspace catalog, so tsdown stops inlining it into `dist/index.mjs`.

PR #47 fixed db tracing by adding `--preload @sentry/node/preload`. It worked, and then commit `5919bc8` silently undid it.

That commit moved `packages/db` from `drizzle(env.g its own pool, adding a direct `import { Pool } from "pg"`. `packages/db` sits under tsdown's `noExternal`, and `pg` was declared only on`, so tsdown treated it as a phantom dependency and pulled pg's entire source into the server bundle.

Sentry's preload hook wraps modules **by specifier bundle is never loaded by specifier, so it is never instrumented. This is a known bundler limitation, not a Sentry bug: getsentry/se

Dev never broke, because `bun --hot src/index.ts` ry is what kept it hidden.

## Impact

Production emitted **zero** `db` spans from Cloud Run revision `00015` onward, while `http.server`, `middleware.hono` and `gen_ai` arrifore the regression: 2026-08-06T06:48Z. Every DB latency widget on the DB Health dashboard was blank for that entire window.

## The fix

tsdown externalizes anything in `package.json` depon the server is the whole change. No config flag needed. `bun install` then links it where `dist/` can resolve it at runtime.

Catalogued rather than pinned per-package so the st drift onto two copies of the driver.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `pg` external in the server build so Sentry’s preload can instrument DB calls, restoring `db` spans in production. Adds `pg` as a direct dependency of `apps/server` and moves it to the workspace catalog to avoid bundling and version drift.

- **Bug Fixes**
  - Prevented `tsdown` from inlining `pg` and documented why it must stay external, since bundling bypasses Sentry’s preload hook.
  - Restored production DB tracing; HTTP spans were unaffected.

- **Dependencies**
  - Added `pg` to `apps/server` dependencies as `catalog:`.
  - Cataloged `pg` in the workspace and updated `packages/db` to `pg: "catalog:"` to ensure a single driver copy.

<sup>Written for commit b12d666f73d7c7acdd89d6915e1bd6fceb36bd83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

