### PR TITLE
feat(web): guard client value-imports off the harness barrel

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,5 +7,24 @@
   "rules": {},
   "env": {
     "builtin": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["apps/web/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@OpenDiagram/harness",
+                "message": "Client code must not import runtime values from the harness barrel. Use `import type` or the lightweight subpath @OpenDiagram/harness/diagram-schema.",
+                "allowTypeImports": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -89,6 +89,30 @@ to the user.
 **Themes own all styling.** A new look means a new file in `theme/` satisfying
 `Theme` and registered in `theme/index.ts`. Nothing else should change.
 
+## Server-only runtime boundary
+
+`@OpenDiagram/harness` is a **server-only runtime** package. Its barrel
+(`src/index.ts`) pulls in the full engine — elkjs graph layout, the renderer and
+the theme registry — so it must never be value-imported from client code
+(`apps/web`). The browser only ever receives **specs + types**; all layout,
+sizing and rendering happens on the server.
+
+| Client wants…                                             | Import this                                               | Why                                                                                |
+| --------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `DiagramSpec`, `ThemeName`, `RenderSkeleton` (types only) | `import type { … } from "@OpenDiagram/harness"`           | Allowed — `verbatimModuleSyntax` erases type imports, nothing ships to the browser |
+| `diagramTypeSchema` (a runtime value)                     | `import { … } from "@OpenDiagram/harness/diagram-schema"` | The lightweight subpath has no engine deps (elkjs, renderer, themes)               |
+
+Rules of thumb:
+
+- `import type` from the barrel is always fine — it is erased at compile time.
+- Any **value** import from the barrel (`layoutDiagram`, `renderToExcalidraw`,
+  themes, …) in client code is a bug: it drags the whole server-only engine
+  into the browser bundle.
+- The root `.oxlintrc.json` enforces this with `no-restricted-imports` on
+  `apps/web/**` (`allowTypeImports: true`, subpath unrestricted), so a stray
+  value import fails `bunx oxlint --deny-warnings` before it can reach a bundle.
+- Server code (`apps/server`, other packages) keeps using the full barrel.
+
 ## Diagram-type dispatch
 
 - `sequence` calls `renderSequenceDiagram(spec, theme)`, which lays out and


### PR DESCRIPTION
## Summary

Implements the full guardrail from issue #23: prevents client code (`apps/web`) from making **value imports** of the `@OpenDiagram/harness` barrel (which pulls the server-only engine — elkjs, renderer, themes — into the browser bundle).

PR #24 already fixed the immediate build break; this PR completes the **guardrail + documentation** part the issue asks for in its *follow-up ideas*.

## Changes

### 1. Root `.oxlintrc.json` — `no-restricted-imports` rule
```json
"overrides": [
  {
    "files": ["apps/web/**"],
    "rules": {
      "no-restricted-imports": [
        "error",
        {
          "paths": [
            {
              "name": "@OpenDiagram/harness",
              "message": "Client code must not import runtime values from the harness barrel. Use `import type` or the lightweight subpath @OpenDiagram/harness/diagram-schema.",
              "allowTypeImports": true
            }
          ]
        }
      ]
    }
  }
]
```
- Scope: `apps/web/**` only (server/packages keep using the barrel freely).
- `allowTypeImports: true` — `import type` from the barrel stays allowed (erased by `verbatimModuleSyntax`).
- The `@OpenDiagram/harness/diagram-schema` subpath is **not** restricted (exact path match).

### 2. `packages/harness/README.md` — "Server-only runtime boundary" section
Documents the boundary: the browser receives specs + types, never the engine; a table of what to import (type-only vs the lightweight subpath); rules of thumb; and the lint rule that enforces this.

## Validation (all green)
- `bunx oxlint --deny-warnings` → 0 warnings, 0 errors (313 files)
- `bunx oxfmt --check` → ok
- `bunx turbo run check-types` → 2 tasks successful (web + server)
- `cd packages/harness && bun test` → 50 pass, 0 fail

**Rule proof (tested locally):**
- `import { layoutDiagram } from "@OpenDiagram/harness"` in apps/web → **fails** with `eslint(no-restricted-imports)` + custom message ✅
- `import type { DiagramSpec } from "@OpenDiagram/harness"` in apps/web → passes ✅
- `import { diagramTypeSchema } from "@OpenDiagram/harness/diagram-schema"` in apps/web → passes ✅
- Same value import in `apps/server` → passes (correct scope) ✅

Closes #23
