### PR TITLE
feat(web): delete projects and files

### DIFF
--- a/apps/server/src/routes/projects/files.ts
+++ b/apps/server/src/routes/projects/files.ts
@@ -276,6 +276,11 @@ filesRoute.patch("/:projectId/files/:fileId", async (c) => {
   return c.json({ file: metaOnly ? row : withContentDefaults({ ...row, ...result.content }) });
 });
 
+/**
+ * Delete from the workspace explorer or the dashboard tree. Ownership rides in
+ * the statement rather than a preceding SELECT, so a file cannot be removed
+ * between the check and the delete. 404 also answers another user's file.
+ */
 filesRoute.delete("/:projectId/files/:fileId", async (c) => {
   const userId = c.get("userId");
   const projectId = c.req.param("projectId");

--- a/apps/server/src/routes/projects/project.ts
+++ b/apps/server/src/routes/projects/project.ts
@@ -143,6 +143,13 @@ projectRoute.patch("/:id", async (c) => {
   return c.json({ project: row });
 });
 
+/**
+ * The dashboard tree's delete action. Files and their content rows go with the
+ * project via the cascade on project_id, so this is the whole cleanup.
+ *
+ * 404 covers "not yours" as well as "gone", deliberately: a distinct 403 would
+ * confirm that some other account owns that id.
+ */
 projectRoute.delete("/:id", async (c) => {
   const userId = c.get("userId");
   const [row] = await db

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -6,12 +6,15 @@ import { authClient } from "@/lib/auth-client";
 import { clearAiSettingsCache } from "@/lib/settings-client";
 import { GuestWelcomeDialog } from "@/components/auth/guest-welcome-dialog";
 import { CheckoutReturn } from "@/components/billing/checkout-return";
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import { DashboardDialogs } from "@/components/dashboard/dashboard-page/DashboardDialogs";
 import { DashboardMain } from "@/components/dashboard/dashboard-page/DashboardMain";
 import { DashboardSidebar } from "@/components/dashboard/dashboard-page/DashboardSidebar";
 import { useDashboardCreation } from "@/components/dashboard/dashboard-page/use-dashboard-creation";
 import { useDashboardData } from "@/components/dashboard/dashboard-page/use-dashboard-data";
+import { useDashboardDeletion } from "@/components/dashboard/dashboard-page/use-dashboard-deletion";
 import { useDashboardRenaming } from "@/components/dashboard/dashboard-page/use-dashboard-renaming";
+import type { DeleteTarget } from "@/components/dashboard/dashboard-page/use-dashboard-deletion";
 import type { Project, ProjectFile } from "@/components/dashboard/dashboard-page/types";
 
 export default function DashboardPage() {
@@ -21,6 +24,7 @@ export default function DashboardPage() {
   const data = useDashboardData(user, session.isPending);
   const creation = useDashboardCreation(data, data.isSignedIn);
   const renaming = useDashboardRenaming(data);
+  const deletion = useDashboardDeletion(data);
   const [signOutPending, setSignOutPending] = useState(false);
   const [signedOutDialogOpen, setSignedOutDialogOpen] = useState(false);
   const accountName = user?.name || user?.email || "Guest";
@@ -71,6 +75,8 @@ export default function DashboardPage() {
           onCommitProject={(project) => void renaming.commitProject(project)}
           onCreateFile={creation.openFileModal}
           onCreateProject={creation.openProjectModal}
+          onDeleteFile={deletion.requestDeleteFile}
+          onDeleteProject={deletion.requestDeleteProject}
           onOpenFile={openFile}
           onOpenProject={openProject}
           onSignOut={() => void signOut()}
@@ -107,7 +113,29 @@ export default function DashboardPage() {
         setProjectName={creation.setProjectName}
         signedOutDialogOpen={signedOutDialogOpen}
       />
+      <ConfirmDeleteDialog
+        open={Boolean(deletion.deleteTarget)}
+        title={deletion.deleteTarget?.kind === "file" ? "Delete file" : "Delete project"}
+        description={describeDeleteTarget(deletion.deleteTarget)}
+        pending={deletion.deletePending}
+        onCancel={deletion.cancelDelete}
+        onConfirm={() => void deletion.confirmDelete()}
+      />
       <GuestWelcomeDialog />
     </main>
   );
+}
+
+/** Names the thing being thrown away, since the dialog is the last chance to read it. */
+function describeDeleteTarget(target: DeleteTarget | null) {
+  if (!target) return "";
+  if (target.kind === "file") {
+    return `"${target.file.name}" will be permanently deleted. This cannot be undone.`;
+  }
+
+  // Files carrying no fileId are the placeholder row an empty project shows, not
+  // stored files, so counting them would promise a deletion that isn't happening.
+  const fileCount = target.project.files.filter((file) => file.fileId).length;
+  const files = fileCount === 1 ? "1 file" : `${fileCount} files`;
+  return `"${target.project.name}" and its ${files} will be permanently deleted. This cannot be undone.`;
 }

--- a/apps/web/src/components/confirm-delete-dialog.tsx
+++ b/apps/web/src/components/confirm-delete-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConfirmDeleteDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  pending?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * The one confirmation shown before anything is deleted, dashboard and workspace.
+ *
+ * Radix rather than `window.confirm` so the copy can name the thing being thrown
+ * away and the confirm button can hold a pending state; the native dialog can do
+ * neither, and it also blocks the event loop while the user reads it.
+ */
+export function ConfirmDeleteDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Delete",
+  pending,
+  onCancel,
+  onConfirm,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && !pending && onCancel()}>
+      <DialogContent className="max-w-[440px] rounded-[16px] border-od-border-soft bg-od-surface p-5">
+        <DialogHeader className="mb-1 text-left">
+          <DialogTitle className="text-[18px]">{title}</DialogTitle>
+          <DialogDescription className="text-[14px] leading-6 text-od-ink-muted">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={pending}
+            className="h-10 rounded-[8px] border border-od-border-soft px-4 text-[14px] font-medium text-od-ink transition hover:bg-od-surface-elevated disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            autoFocus
+            onClick={onConfirm}
+            disabled={pending}
+            className="h-10 rounded-[8px] bg-red-600 px-4 text-[14px] font-medium text-white transition hover:bg-red-700 disabled:cursor-wait disabled:opacity-70"
+          >
+            {pending ? "Deleting..." : confirmLabel}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/confirm-delete-dialog.tsx
+++ b/apps/web/src/components/confirm-delete-dialog.tsx
@@ -36,7 +36,10 @@ export function ConfirmDeleteDialog({
 }: ConfirmDeleteDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(next) => !next && !pending && onCancel()}>
-      <DialogContent className="max-w-[440px] rounded-[16px] border-od-border-soft bg-od-surface p-5">
+      <DialogContent
+        showCloseButton={!pending}
+        className="max-w-[440px] rounded-[16px] border-od-border-soft bg-od-surface p-5"
+      >
         <DialogHeader className="mb-1 text-left">
           <DialogTitle className="text-[18px]">{title}</DialogTitle>
           <DialogDescription className="text-[14px] leading-6 text-od-ink-muted">
@@ -54,7 +57,6 @@ export function ConfirmDeleteDialog({
           </button>
           <button
             type="button"
-            autoFocus
             onClick={onConfirm}
             disabled={pending}
             className="h-10 rounded-[8px] bg-red-600 px-4 text-[14px] font-medium text-white transition hover:bg-red-700 disabled:cursor-wait disabled:opacity-70"

--- a/apps/web/src/components/dashboard/dashboard-page/ProjectTree.tsx
+++ b/apps/web/src/components/dashboard/dashboard-page/ProjectTree.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Pencil, Plus } from "lucide-react";
+import { ChevronDown, Pencil, Plus, Trash2 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Project, ProjectFile } from "./types";
 import { getFileIcon } from "./utils";
@@ -17,6 +17,8 @@ export interface ProjectTreeProps {
   onCommitProject: (project: Project) => void;
   onCreateFile: (projectId: string) => void;
   onCreateProject: () => void;
+  onDeleteFile: (file: ProjectFile) => void;
+  onDeleteProject: (project: Project) => void;
   onOpenFile: (file: ProjectFile) => void;
   onOpenProject: (project: Project) => void;
   onToggleProject: (projectId: string) => void;
@@ -104,6 +106,14 @@ function ProjectRow({ project, ...props }: ProjectTreeProps & { project: Project
             </button>
             <button
               type="button"
+              onClick={() => props.onDeleteProject(project)}
+              aria-label={`Delete project ${project.name}`}
+              className="grid h-6 w-6 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint opacity-0 transition hover:bg-red-50 hover:text-red-600 group-hover/prow:opacity-100 focus-visible:opacity-100"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
               onClick={() => props.onToggleProject(project.id)}
               aria-label={expanded ? "Collapse" : "Expand"}
               aria-expanded={expanded}
@@ -119,7 +129,7 @@ function ProjectRow({ project, ...props }: ProjectTreeProps & { project: Project
       {expanded && (
         <div className="mt-1 grid gap-0.5 pl-5">
           {project.files.map((file) => (
-            <FileRow key={file.key} file={file} {...props} />
+            <FileRow key={file.key} file={file} project={project} {...props} />
           ))}
           <button
             type="button"
@@ -135,7 +145,15 @@ function ProjectRow({ project, ...props }: ProjectTreeProps & { project: Project
   );
 }
 
-function FileRow({ file, ...props }: ProjectTreeProps & { file: ProjectFile }) {
+function FileRow({
+  file,
+  project,
+  ...props
+}: ProjectTreeProps & { file: ProjectFile; project: Project }) {
+  // A guest draft holds exactly one file and cannot be given a second (see
+  // use-dashboard-creation), so deleting it is deleting the project. Only the
+  // project row offers that, or the two rows would mean the same thing.
+  const deletable = Boolean(file.fileId) && project.source === "saved";
   const Icon = getFileIcon(file.kind);
   return (
     <div className="group/file flex h-7 items-center gap-2 rounded-[7px] px-2 text-[12px] text-od-ink-muted transition hover:bg-od-canvas/45 hover:text-od-ink">
@@ -164,6 +182,16 @@ function FileRow({ file, ...props }: ProjectTreeProps & { file: ProjectFile }) {
               className="grid h-5 w-5 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint opacity-0 transition hover:bg-od-canvas/60 hover:text-od-ink group-hover/file:opacity-100"
             >
               <Pencil className="h-3 w-3" />
+            </button>
+          )}
+          {deletable && (
+            <button
+              type="button"
+              onClick={() => props.onDeleteFile(file)}
+              aria-label={`Delete file ${file.name}`}
+              className="grid h-5 w-5 shrink-0 cursor-pointer place-items-center rounded-[5px] text-od-ink-faint opacity-0 transition hover:bg-red-50 hover:text-red-600 group-hover/file:opacity-100 focus-visible:opacity-100"
+            >
+              <Trash2 className="h-3 w-3" />
             </button>
           )}
         </>

--- a/apps/web/src/components/dashboard/dashboard-page/use-dashboard-deletion.ts
+++ b/apps/web/src/components/dashboard/dashboard-page/use-dashboard-deletion.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { deleteGuestProjectDraft } from "@/lib/guest-drafts";
 import { forgetLocalFiles } from "@/lib/local-file-cleanup";
+import { cancelQueuedProjectFilePatch } from "@/lib/project-file-sync";
 import { deleteProject, deleteProjectFile } from "@/lib/projects-client";
 import type { DashboardData } from "./use-dashboard-data";
 import type { Project, ProjectFile } from "./types";
@@ -33,6 +34,12 @@ export function useDashboardDeletion(data: DashboardData) {
       deleteGuestProjectDraft(project.id);
       data.setGuestDrafts((current) => current.filter((draft) => draft.id !== project.id));
     } else {
+      // Queued autosave from a still-open workspace tab shares this SPA and its
+      // module-scoped write queue; drop it before the DELETE or it lands after
+      // and repopulates the file's local IndexedDB copy.
+      for (const file of project.files) {
+        if (file.fileId) cancelQueuedProjectFilePatch(file.fileId);
+      }
       await deleteProject(project.id);
       data.setSavedProjects((current) => current.filter((item) => item.id !== project.id));
       data.setFilesByProject((current) => {
@@ -60,6 +67,7 @@ export function useDashboardDeletion(data: DashboardData) {
       } else {
         const { file } = target;
         if (!file.fileId) return;
+        cancelQueuedProjectFilePatch(file.fileId);
         await deleteProjectFile(file.projectId, file.fileId);
         forgetLocalFiles([file.fileId]);
         data.setFilesByProject((current) => ({

--- a/apps/web/src/components/dashboard/dashboard-page/use-dashboard-deletion.ts
+++ b/apps/web/src/components/dashboard/dashboard-page/use-dashboard-deletion.ts
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { deleteGuestProjectDraft } from "@/lib/guest-drafts";
+import { forgetLocalFiles } from "@/lib/local-file-cleanup";
+import { deleteProject, deleteProjectFile } from "@/lib/projects-client";
+import type { DashboardData } from "./use-dashboard-data";
+import type { Project, ProjectFile } from "./types";
+
+export type DeleteTarget =
+  | { kind: "project"; project: Project }
+  | { kind: "file"; file: ProjectFile };
+
+export function useDashboardDeletion(data: DashboardData) {
+  const [target, setTarget] = useState<DeleteTarget | null>(null);
+  const [pending, setPending] = useState(false);
+
+  function requestDeleteProject(project: Project) {
+    setTarget({ kind: "project", project });
+  }
+
+  function requestDeleteFile(file: ProjectFile) {
+    if (!file.fileId) return;
+    setTarget({ kind: "file", file });
+  }
+
+  function cancelDelete() {
+    if (pending) return;
+    setTarget(null);
+  }
+
+  async function deleteTargetProject(project: Project) {
+    if (project.source === "guest") {
+      deleteGuestProjectDraft(project.id);
+      data.setGuestDrafts((current) => current.filter((draft) => draft.id !== project.id));
+    } else {
+      await deleteProject(project.id);
+      data.setSavedProjects((current) => current.filter((item) => item.id !== project.id));
+      data.setFilesByProject((current) => {
+        const { [project.id]: _removed, ...rest } = current;
+        return rest;
+      });
+    }
+    // Guest and saved alike: both keep scenes and chats in IndexedDB keyed by
+    // file id. Placeholder rows carry no fileId and own nothing to forget.
+    forgetLocalFiles(project.files.flatMap((file) => (file.fileId ? [file.fileId] : [])));
+
+    // The tree keeps one project expanded by id, and that id is about to name
+    // nothing, which leaves the accordion stuck open on a gap.
+    data.setExpandedProjectId((current) => (current === project.id ? null : current));
+  }
+
+  async function confirmDelete() {
+    if (!target || pending) return;
+    setPending(true);
+
+    try {
+      if (target.kind === "project") {
+        await deleteTargetProject(target.project);
+        toast.success(`Deleted "${target.project.name}".`);
+      } else {
+        const { file } = target;
+        if (!file.fileId) return;
+        await deleteProjectFile(file.projectId, file.fileId);
+        forgetLocalFiles([file.fileId]);
+        data.setFilesByProject((current) => ({
+          ...current,
+          [file.projectId]: (current[file.projectId] ?? []).filter(
+            (item) => item.id !== file.fileId,
+          ),
+        }));
+        toast.success(`Deleted "${file.name}".`);
+      }
+      setTarget(null);
+    } catch (error) {
+      const fallback =
+        target.kind === "project" ? "Could not delete project." : "Could not delete file.";
+      toast.error(error instanceof Error ? error.message : fallback);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return {
+    cancelDelete,
+    confirmDelete,
+    deletePending: pending,
+    deleteTarget: target,
+    requestDeleteFile,
+    requestDeleteProject,
+  };
+}

--- a/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
+++ b/apps/web/src/components/whiteboard/workspace-layout/WorkspaceSidebar.tsx
@@ -1,6 +1,7 @@
-import type { ComponentType } from "react";
+import { useState, type ComponentType } from "react";
 import Link from "next/link";
 import { ArrowLeft, FileText, PanelLeftClose, PenTool, Plus, Trash2 } from "lucide-react";
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -48,6 +49,8 @@ export function WorkspaceSidebar({
   onBackToDashboard,
   onSignOut,
 }: WorkspaceSidebarProps) {
+  const [pendingDelete, setPendingDelete] = useState<WorkspaceSidebarFile | null>(null);
+
   return (
     <aside
       className="group/sidebar relative hidden h-full shrink-0 flex-col border-r border-od-border-soft bg-od-surface lg:flex"
@@ -141,7 +144,7 @@ export function WorkspaceSidebar({
                     </button>
                     <button
                       type="button"
-                      onClick={() => onDeleteFile(file.id)}
+                      onClick={() => setPendingDelete(file)}
                       aria-label={`Delete ${file.name}`}
                       className="grid h-7 w-7 shrink-0 place-items-center rounded-[7px] text-od-ink-faint opacity-0 transition hover:bg-red-50 hover:text-red-600 group-hover/file:opacity-100 focus:opacity-100"
                     >
@@ -159,6 +162,17 @@ export function WorkspaceSidebar({
         accountImage={accountImage}
         accountName={accountName}
         onSignOut={onSignOut}
+      />
+
+      <ConfirmDeleteDialog
+        open={Boolean(pendingDelete)}
+        title="Delete file"
+        description={`"${pendingDelete?.name}" will be permanently deleted. This cannot be undone.`}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => {
+          if (pendingDelete) onDeleteFile(pendingDelete.id);
+          setPendingDelete(null);
+        }}
       />
     </aside>
   );

--- a/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceFileActions.ts
+++ b/apps/web/src/components/whiteboard/workspace-layout/useWorkspaceFileActions.ts
@@ -3,7 +3,8 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useRouter } from "next/navigation";
 import type { StoredChatMessage } from "@/lib/chat-history";
 import { saveGuestProjectDraft, type GuestProjectDraft } from "@/lib/guest-drafts";
-import { deleteLocalChat, writeLocalChat } from "@/lib/local-chat";
+import { writeLocalChat } from "@/lib/local-chat";
+import { forgetLocalFiles } from "@/lib/local-file-cleanup";
 import { cancelQueuedProjectFilePatch, queueProjectFilePatch } from "@/lib/project-file-sync";
 import {
   createProjectFile,
@@ -166,7 +167,6 @@ export function useWorkspaceFileActions(options: FileActionsOptions) {
 
   async function deleteWorkspaceFile(fileId: string) {
     if (!isSignedIn) return setSaveError("Log in to save your project before deleting files.");
-    if (!window.confirm("Delete this file? This cannot be undone.")) return;
     setSaveError(null);
     setSaveStatus("saving");
     const deletingActiveFile = persistence.activeFileRef.current?.id === fileId;
@@ -181,7 +181,7 @@ export function useWorkspaceFileActions(options: FileActionsOptions) {
     try {
       await deleteProjectFile(projectId, fileId);
       removeStoredFile(fileId);
-      void deleteLocalChat(fileId);
+      forgetLocalFiles([fileId]);
       const nextFile = sidebarFiles.find((file) => file.id !== fileId);
       if (persistence.activeFileRef.current?.id === fileId) {
         setActiveFile(null);

--- a/apps/web/src/lib/local-file-cleanup.ts
+++ b/apps/web/src/lib/local-file-cleanup.ts
@@ -1,0 +1,25 @@
+import { deleteLocalChat } from "@/lib/local-chat";
+import { deleteLocalScene } from "@/lib/local-scene";
+import { cancelQueuedProjectFilePatch } from "@/lib/project-file-sync";
+import { resetSceneDelta } from "@/lib/scene-delta";
+
+/**
+ * Drop every browser-side trace of files the server has just deleted.
+ *
+ * The four stores outlive the row on their own: IndexedDB scenes and chats are
+ * keyed by file id and nothing expires them, the delta baseline sits in memory,
+ * and a queued PATCH would fire at a 404 afterwards. Deleting the row without
+ * this leaves a scene blob (KBs to MBs each) on the device forever, and the ids
+ * are random so nothing ever collides with it to clean it up.
+ *
+ * Call it after the DELETE succeeds, not before: a failed request must leave the
+ * local copy intact, since it is the only remaining one.
+ */
+export function forgetLocalFiles(fileIds: string[]) {
+  for (const fileId of fileIds) {
+    cancelQueuedProjectFilePatch(fileId);
+    resetSceneDelta(fileId);
+    void deleteLocalScene(fileId);
+    void deleteLocalChat(fileId);
+  }
+}

--- a/apps/web/src/lib/projects-client/projects.ts
+++ b/apps/web/src/lib/projects-client/projects.ts
@@ -78,3 +78,12 @@ export async function updateProject(
   if (!response.ok) throw new Error(data?.error ?? "Could not rename project.");
   return data.project;
 }
+
+export async function deleteProject(id: string): Promise<void> {
+  const response = await fetch(`${env.NEXT_PUBLIC_SERVER_URL}/api/projects/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  const data = await readProjectResponse(response);
+  if (!response.ok) throw new Error(data?.error ?? "Could not delete project.");
+}


### PR DESCRIPTION
Closes #59.

The dashboard tree offered rename and nothing else, so a project could only ever be abandoned, never removed. Both server routes (`DELETE /api/projects/:id`, `DELETE /api/projects/:projectId/files/:fileId`) already existed and were already authorized; this adds the client function, the UI, and the local cleanup that was missing everywhere.

- Trash actions on both row types in the dashboard tree, behind a confirmation  dialog that names the target and holds a pending state.
- Guest drafts get project-level delete only. A draft holds exactly one file and `createFile` refuses to give it a second, so deleting that file is deleting the project. Guest deletes stay entirely local, which is where the draft lives.
- The workspace explorer's `window.confirm` is replaced by the same dialog.
- **Bug fix:** every delete path orphaned the file's cached scene in IndexedDB.  `removeStoredFile` only drops the zustand sidebar entry, and nothing called  `deleteLocalScene`. `forgetLocalFiles` now clears scene, chat, delta baseline and any queued PATCH together, after the request succeeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #59. The dashboard tree previously offered rename but no way to remove anything. This adds delete actions for projects and files, behind a confirmation dialog that names the target and shows a pending state.

Guest drafts only get project-level delete, since a draft holds exactly one file and deleting that file is the same as deleting the project. Guest deletes stay entirely local.

**Bug Fixes**
- Deleting a file previously left its scene, chat, and delta baseline cached in IndexedDB forever, and a queued autosave PATCH from a still-open workspace tab could repopulate the local copy after the DELETE. `forgetLocalFiles` now clears the caches once the request succeeds, and queued PATCHes are canceled before it, so a failed delete keeps the local copy intact.
- The workspace explorer's `window.confirm` is replaced with the same dialog, which no longer auto-focuses the delete button (Enter could confirm before the user chose) and disables its close button while pending.

<sup>Written for commit 850c56acbe6864f9c632ffbcf77b737fc44a5503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

