### PR TITLE
optimize docker build for gcp 

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,30 +1,58 @@
-# syntax=docker/dockerfile:1.7
-FROM oven/bun:1-slim
+# syntax=docker/dockerfile:1.20
+# 1.20 for COPY --parents (manifest-only copies that keep apps/*/packages/* paths).
 
+FROM oven/bun:1-slim AS deps
+WORKDIR /app
+ENV SKIP_ENV_VALIDATION=1
+
+# Manifests only, so editing src/ doesn't bust this layer's install cache.
+COPY package.json bun.lock bunfig.toml ./
+COPY --parents apps/*/package.json packages/*/package.json ./
+# server... = server plus every workspace it depends on, transitively.
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+  bun install --filter 'server...' --frozen-lockfile
+
+FROM deps AS build
+ENV NODE_ENV=production
+COPY --parents apps/server packages/config packages/auth packages/db packages/env packages/harness ./
+RUN bun run --filter server build
+
+FROM oven/bun:1-slim AS runtime
 WORKDIR /app
 
 # git is required at runtime: repo import shells out to `git clone`.
-# ca-certificates so the HTTPS clone against github.com verifies.
+# ca-certificates ships preinstalled on this base image already.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git ca-certificates \
+  && apt-get install -y --no-install-recommends git=1:2.47.3-0+deb13u1 \
   && rm -rf /var/lib/apt/lists/*
 
 ENV SKIP_ENV_VALIDATION=1
-
-COPY . .
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install
-
-ENV NODE_ENV=production
-RUN bun run build --filter=server
-# ELK worker must be resolvable from dist/ after bundling.
-# createRequire(import.meta.url) resolves from dist/index.mjs, so symlink
-# elkjs into server's node_modules where it can walk up to find it.
-RUN mkdir -p /app/apps/server/node_modules && \
-    ln -s /app/node_modules/elkjs /app/apps/server/node_modules/elkjs
+COPY package.json bun.lock bunfig.toml ./
+COPY --parents apps/*/package.json packages/*/package.json ./
+# --omit=peer,optional: evlog's framework integrations declare next/hono/express/etc
+# as optional peers, and bun auto-installs any optional peer already resolved
+# elsewhere in the lockfile (apps/web's `next`) even though server never needs it.
+# Without --omit this pulled in next + its swc binaries + sharp (~450MB dead weight).
+# https://github.com/oven-sh/bun/issues/26400
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+  bun install --filter 'server...' --production --omit=peer --omit=optional --frozen-lockfile
 ENV SKIP_ENV_VALIDATION=
+ENV NODE_ENV=production
 
-EXPOSE 3000
+COPY --from=build /app/apps/server/dist /app/apps/server/dist
+
+# evlog's fs drain writes every request to ./.evlog unconditionally (src/index.ts).
+# Precreate it owned by the runtime user or the first request hits EACCES.
+RUN mkdir -p /app/apps/server/.evlog && chown bun:bun /app/apps/server/.evlog
 
 WORKDIR /app/apps/server
+USER bun
+
+EXPOSE 3000
+# Cloud Run ignores this (it has its own startup/liveness probes); this is for
+# plain `docker run` / compose. https://docs.cloud.google.com/run/docs/configuring/healthchecks
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD bun -e "fetch('http://localhost:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 # --preload is load-bearing for db tracing. See the Sentry note in src/index.ts.
 CMD ["bun", "run", "--preload", "@sentry/node/preload", "dist/index.mjs"]

--- a/bun.lock
+++ b/bun.lock
@@ -219,8 +219,10 @@
       "version": "0.0.1",
       "dependencies": {
         "elkjs": "^0.11.1",
-        "typescript": "catalog:",
         "zod": "catalog:",
+      },
+      "devDependencies": {
+        "typescript": "catalog:",
       },
     },
   },

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "elkjs": "^0.11.1",
-    "typescript": "catalog:",
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shrinks the server Docker image from 2.62GB to 551MB via a multi-stage build, and switches the runtime stage to a non-root user with a HEALTHCHECK for local runs.

- Production installs only the server workspace graph (`--filter 'server...'`) with `--omit=peer --omit=optional` to drop ~450MB of unused Next.js, swc, and sharp dependencies.
- Copied manifests before source so editing `src/` no longer busts the install cache.
- Moved `typescript` to `devDependencies` in `packages/harness` so production installs skip the ~24MB compiler.
- Removed the manual `elkjs` symlink since bun's isolated linker resolves it correctly.
- Precreated `.evlog` owned by the runtime user so evlog's fs drain doesn't fail with EACCES.

<sup>Written for commit b8ed8e1b1a97486d332f47d003e28d1d939cca83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

