### PR TITLE
feat: email and subscription verification guards

### DIFF
--- a/apps/client/src/components/app/Sidebar.tsx
+++ b/apps/client/src/components/app/Sidebar.tsx
@@ -8,10 +8,17 @@ import {
   DialogTitle,
   DialogDescription,
   useKumoToastManager,
+  Meter,
 } from "@cloudflare/kumo";
 import { useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { projectsQueryOptions, createProject, authClient } from "#/lib/api";
+import {
+  projectsQueryOptions,
+  createProject,
+  authClient,
+  billingQueryOptions,
+  creationQuotaQueryOptions,
+} from "#/lib/api";
 import { clearAiSettingsCache } from "#/lib/api/settings-client";
 import { getInitials } from "#/lib/utils";
 import { HeroButton, CustomButton } from "#/components/ui/button";
@@ -38,6 +45,8 @@ export const SideBar = ({
   const [newProjectName, setNewProjectName] = useState("");
   const [isLoggedOutOpen, setIsLoggedOutOpen] = useState(false);
 
+  const { data: billing } = useQuery(billingQueryOptions);
+  const { data: quota } = useQuery(creationQuotaQueryOptions);
   const { data: projects, isLoading: isProjectsLoading } = useQuery({
     ...projectsQueryOptions,
     enabled: isAuthenticated,
@@ -186,10 +195,73 @@ export const SideBar = ({
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content
                     side="top"
-                    align="end"
-                    sideOffset={10}
-                    className="p-1 bg-white border border-gray-200/80 rounded-xl shadow-[0_8px_30px_rgb(0,0,0,0.06),0_1px_2px_rgba(0,0,0,0.02)] flex flex-col gap-0.5 min-w-[130px] z-[9999] font-sans"
+                    align="start"
+                    alignOffset={-180}
+                    sideOffset={18}
+                    className="p-2.5 bg-white border border-gray-200/80 rounded-2xl shadow-[0_8px_30px_rgb(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.02)] flex flex-col gap-0.5 min-w-[230px] z-[9999] font-geist"
                   >
+                    {billing &&
+                      quota &&
+                      billing.billingEnabled &&
+                      (() => {
+                        const limit = quota.limit ?? 0;
+                        const remaining = quota.remaining ?? 0;
+                        const percentage =
+                          limit > 0 ? Math.min(100, Math.max(0, (remaining / limit) * 100)) : 0;
+                        const periodText = quota.resetAt ? "this month" : "lifetime";
+
+                        let indicatorColor = "bg-red-500";
+                        if (percentage >= 80) {
+                          indicatorColor = "bg-green-500";
+                        } else if (percentage >= 20) {
+                          indicatorColor = "bg-yellow-500";
+                        }
+
+                        const isFree = billing.planId === "free" || billing.planId === "guest";
+
+                        return (
+                          <>
+                            <div className="px-3 py-2.5 select-none flex flex-col gap-3">
+                              <div className="flex items-center justify-between gap-2">
+                                <div>
+                                  <p className="text-[9px] font-bold text-gray-400 uppercase tracking-wider">
+                                    Plan
+                                  </p>
+                                  <p className="text-xs font-bold text-gray-900 mt-0.5">
+                                    {billing.planId === "pro" ? "Pro Plan" : "Free Plan"}
+                                  </p>
+                                </div>
+                                {!isFree && (
+                                  <span className="rounded-full bg-orange px-2 py-0.5 text-[8px] font-bold text-white uppercase tracking-wider shadow-sm">
+                                    Active
+                                  </span>
+                                )}
+                              </div>
+                              <div className="w-full">
+                                <Meter
+                                  value={percentage}
+                                  label="Credits"
+                                  customValue={`${remaining} of ${limit} left`}
+                                  trackClassName="bg-gray-100"
+                                  indicatorClassName={indicatorColor}
+                                />
+                                <p className="text-[9px] text-gray-400 font-semibold mt-1.5 capitalize">
+                                  Resets: {periodText}
+                                </p>
+                              </div>
+                              {isFree && (
+                                <HeroButton
+                                  text="Upgrade to Pro"
+                                  color="blue"
+                                  onClick={() => navigate({ to: "/settings" as any })}
+                                  className="w-full justify-center h-8 py-0 text-xs font-semibold rounded-xl shadow-none mt-3"
+                                />
+                              )}
+                            </div>
+                            <DropdownMenu.Separator className="h-[1px] bg-gray-100 my-1" />
+                          </>
+                        );
+                      })()}
                     <DropdownMenu.Item
                       onClick={() => navigate({ to: "/settings" as any })}
                       className="px-2.5 py-1.5 rounded-lg text-xs flex items-center gap-2 text-gray-700 hover:bg-gray-50 hover:text-gray-950 transition cursor-pointer"

--- a/apps/client/src/components/auth/auth.tsx
+++ b/apps/client/src/components/auth/auth.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   Button,
   Input,
@@ -70,15 +71,22 @@ export default function SignUpPage({ initialTab = "signup", redirect, urlError }
   const [suEmail, setSuEmail] = useState("");
   const [suPwd, setSuPwd] = useState("");
   const [suTerms, setSuTerms] = useState(false);
+  // Verification States
+  const [isVerifyingEmail, setIsVerifyingEmail] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState("");
+  const [checkLoading, setCheckLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const queryClient = useQueryClient();
 
   const { data: session, isPending } = authClient.useSession();
 
   // Redirect if session is active
   useEffect(() => {
     if (!isPending && session?.user) {
+      if (isVerifyingEmail) return;
       navigate({ to: redirectTo as any, replace: true });
     }
-  }, [isPending, redirectTo, navigate, session]);
+  }, [isPending, redirectTo, navigate, session, isVerifyingEmail]);
 
   // Display OAuth error if present
   useEffect(() => {
@@ -151,6 +159,7 @@ export default function SignUpPage({ initialTab = "signup", redirect, urlError }
           email: suEmail,
           password: suPwd,
           name: `${suFirst} ${suLast}`.trim(),
+          callbackURL: window.location.origin + "/app",
         });
         if (error) {
           setLoading(false);
@@ -160,7 +169,9 @@ export default function SignUpPage({ initialTab = "signup", redirect, urlError }
             variant: "error",
           });
         } else {
-          finishAuthentication();
+          setRegisteredEmail(suEmail);
+          setLoading(false);
+          setIsVerifyingEmail(true);
         }
       }
     } catch {
@@ -171,6 +182,68 @@ export default function SignUpPage({ initialTab = "signup", redirect, urlError }
         variant: "error",
       });
     }
+  }
+  async function checkVerificationStatus() {
+    setCheckLoading(true);
+    try {
+      const { data, error } = await authClient.getSession();
+      if (error) throw new Error(error.message ?? "Failed to fetch session.");
+
+      if (data?.user?.emailVerified) {
+        toastManager.add({
+          title: "Email verified",
+          description: "Your email has been verified successfully. Welcome to OpenDiagram!",
+          variant: "success",
+        });
+        await queryClient.invalidateQueries({ queryKey: ["auth", "session"] });
+        navigate({ to: redirectTo as any });
+      } else {
+        toastManager.add({
+          title: "Not verified yet",
+          description:
+            "We couldn't verify your email yet. Please check your inbox and click the verification link.",
+          variant: "warning",
+        });
+      }
+    } catch (err: unknown) {
+      toastManager.add({
+        title: "Error checking status",
+        description: err instanceof Error ? err.message : "Something went wrong",
+        variant: "error",
+      });
+    } finally {
+      setCheckLoading(false);
+    }
+  }
+
+  async function resendVerification() {
+    if (!registeredEmail) return;
+    setResendLoading(true);
+    try {
+      const { error } = await authClient.sendVerificationEmail({
+        email: registeredEmail,
+        callbackURL: window.location.origin + "/app",
+      });
+      if (error) throw new Error(error.message ?? "Failed to send email.");
+      toastManager.add({
+        title: "Verification email sent",
+        description: "Please check your inbox (and spam folder) for the verification link.",
+        variant: "success",
+      });
+    } catch (err: unknown) {
+      toastManager.add({
+        title: "Failed to send email",
+        description: err instanceof Error ? err.message : "Something went wrong",
+        variant: "error",
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
+  async function skipVerification() {
+    await queryClient.invalidateQueries({ queryKey: ["auth", "session"] });
+    navigate({ to: redirectTo as any });
   }
 
   function switchTab(nextTab: "signin" | "signup") {
@@ -200,7 +273,61 @@ export default function SignUpPage({ initialTab = "signup", redirect, urlError }
             <Text bold>OpenDiagram</Text>
           </div>
 
-          {success ? (
+          {isVerifyingEmail ? (
+            <div className="flex flex-col gap-6 font-geist">
+              <div>
+                <Text variant="heading2" as="h1" DANGEROUS_className="mb-2">
+                  Verify your email
+                </Text>
+                <Text variant="secondary" DANGEROUS_className="leading-relaxed">
+                  We sent a verification link to{" "}
+                  <span className="font-semibold text-gray-900">{registeredEmail}</span>. Please
+                  click the link in your email to verify your account and unlock your full 25
+                  credits.
+                </Text>
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <Button
+                  variant="primary"
+                  type="button"
+                  className="w-full justify-center cursor-pointer h-10 text-sm font-semibold rounded-xl"
+                  onClick={checkVerificationStatus}
+                  disabled={checkLoading}
+                >
+                  {checkLoading ? (
+                    <div className="flex items-center justify-center gap-2">
+                      <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                      <span>Checking...</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-center gap-2">
+                      <span>Check Verification Status</span>
+                      <ArrowRightIcon size={16} />
+                    </div>
+                  )}
+                </Button>
+
+                <Button
+                  variant="secondary"
+                  type="button"
+                  className="w-full justify-center cursor-pointer h-10 text-sm font-semibold rounded-xl"
+                  onClick={resendVerification}
+                  disabled={resendLoading}
+                >
+                  {resendLoading ? "Resending..." : "Resend Verification Link"}
+                </Button>
+
+                <button
+                  type="button"
+                  onClick={skipVerification}
+                  className="mt-3 text-center text-xs font-semibold text-gray-500 hover:text-gray-900 underline underline-offset-4 cursor-pointer"
+                >
+                  Skip to Dashboard (Unverified)
+                </button>
+              </div>
+            </div>
+          ) : success ? (
             <div className="flex flex-col items-center justify-center py-8 text-center">
               <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-kumo-success-base/10 text-kumo-success-base">
                 <span className="text-2xl font-bold">✓</span>

--- a/apps/client/src/components/billing/CheckoutReturn.tsx
+++ b/apps/client/src/components/billing/CheckoutReturn.tsx
@@ -31,11 +31,14 @@ export function CheckoutReturn() {
 
   const { checkout, subscription_id: subscriptionId, status: urlStatus } = Route.useSearch();
   const isCheckoutReturn = checkout === "success" || Boolean(subscriptionId);
-  const handled = useRef(false);
+  const processedId = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!isCheckoutReturn || handled.current) return;
-    handled.current = true;
+    if (!isCheckoutReturn) return;
+    if (subscriptionId && processedId.current === subscriptionId) return;
+    if (subscriptionId) {
+      processedId.current = subscriptionId;
+    }
 
     let live = true;
 
@@ -99,7 +102,6 @@ export function CheckoutReturn() {
 
     return () => {
       live = false;
-      handled.current = false;
     };
   }, [isCheckoutReturn, subscriptionId, urlStatus, navigate, queryClient, toastManager]);
 

--- a/apps/client/src/components/settings/PricingPlans.tsx
+++ b/apps/client/src/components/settings/PricingPlans.tsx
@@ -1,7 +1,15 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Check, ExternalLink, Loader2, X, Lock } from "lucide-react";
+import {
+  CheckIcon,
+  XIcon,
+  LockIcon,
+  ArrowSquareOutIcon,
+  CircleNotchIcon,
+} from "@phosphor-icons/react";
 import { billingQueryOptions, openBillingPortal, startCheckout } from "#/lib/api/billing-client";
+import { creationQuotaQueryOptions } from "#/lib/api/usage-client";
+import { sessionQueryOptions } from "#/lib/api/session";
 import { HeroButton } from "#/components/ui/button";
 
 function proFeatures(monthlyCredits: number): readonly string[] {
@@ -26,7 +34,9 @@ function Notice({ children }: { children: React.ReactNode }) {
 function PlanCard({
   name,
   price,
+  originalPrice,
   priceSuffix,
+  priceBadge,
   tagline,
   creditsInfo,
   featureGroupTitle,
@@ -36,7 +46,9 @@ function PlanCard({
 }: {
   name: string;
   price: string;
+  originalPrice?: string;
   priceSuffix?: string;
+  priceBadge?: string;
   tagline: string;
   creditsInfo: { amount: string; detail: string; helperText?: string };
   featureGroupTitle: string;
@@ -51,27 +63,27 @@ function PlanCard({
       } font-geist w-full`}
     >
       {highlighted && (
-        <span className="absolute -top-2.5 right-4 rounded-full bg-blue-600 px-3 py-0.5 text-[9px] font-bold text-white uppercase tracking-wider shadow-sm">
+        <span className="absolute -top-2.5 right-4 rounded-full bg-orange px-3 py-0.5 text-[9px] font-bold text-white uppercase tracking-wider shadow-sm">
           Best Value
         </span>
       )}
 
       {/* Header */}
-      <h2 className={`text-base font-bold ${highlighted ? "text-gray-900" : "text-gray-500"}`}>
+      <h2 className={`text-lg font-bold ${highlighted ? "text-gray-900" : "text-gray-500"}`}>
         {name}
       </h2>
-      <p className="mt-1 text-xs text-gray-500 leading-normal mb-4">{tagline}</p>
+      <p className="mt-1 text-sm text-gray-500 leading-normal mb-4">{tagline}</p>
 
       {/* Dynamic Credit Nested Box */}
       <div className="w-full rounded-xl bg-gray-50 border border-gray-200/60 p-4 flex flex-col gap-1 mb-5">
-        <div className="flex items-center gap-1.5 text-sm font-bold text-gray-900">
-          <span className="text-blue-600 font-medium">✦</span>
+        <div className="flex items-center gap-1.5 text-base font-bold text-gray-900">
+          <span className="text-orange font-medium">✦</span>
           <span>{creditsInfo.amount}</span>
         </div>
-        <p className="text-xs text-gray-500 font-medium leading-normal">{creditsInfo.detail}</p>
+        <p className="text-sm text-gray-500 font-medium leading-normal">{creditsInfo.detail}</p>
         {creditsInfo.helperText && (
-          <div className="mt-2 border-t border-gray-200/40 pt-2 text-[10px] text-gray-400 font-semibold flex items-center gap-1">
-            <span className="text-blue-600 font-medium">✓</span>
+          <div className="mt-2 border-t border-gray-200/40 pt-2 text-xs text-gray-400 font-semibold flex items-center gap-1">
+            <CheckIcon className="size-3 text-orange shrink-0" weight="bold" />
             <span>{creditsInfo.helperText}</span>
           </div>
         )}
@@ -79,12 +91,26 @@ function PlanCard({
 
       {/* Pricing */}
       <div className="flex flex-col mb-4">
-        <div className="flex items-baseline text-gray-900">
-          <span className="text-3xl font-extrabold tracking-tight">{price}</span>
-          {priceSuffix && (
-            <span className="ml-1 text-xs font-semibold text-gray-500">{priceSuffix}</span>
+        <div className="flex flex-wrap items-center gap-2 mb-1">
+          {originalPrice && (
+            <span className="text-xl font-medium text-gray-400 line-through select-none leading-none">
+              {originalPrice}
+            </span>
           )}
+          <div className="flex items-baseline text-gray-900">
+            <span className="text-4xl font-extrabold tracking-tight">{price}</span>
+            {priceSuffix && (
+              <span className="ml-1 text-sm font-semibold text-gray-500">{priceSuffix}</span>
+            )}
+          </div>
         </div>
+        {priceBadge && (
+          <div className="mt-1.5 flex">
+            <span className="inline-flex items-center rounded-md bg-orange/10 px-2 py-0.5 text-xs font-semibold text-orange ring-1 ring-inset ring-orange/20">
+              {priceBadge}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Children Actions (Upgrade button / code input / Current plan) */}
@@ -95,11 +121,11 @@ function PlanCard({
 
       {/* Feature Groups */}
       <div className="w-full mt-2">
-        <h3 className="text-[10px] font-bold tracking-wider text-gray-400 uppercase flex items-center gap-1.5 mb-3 select-none">
-          <Lock className="size-3 text-gray-400" />
+        <h3 className="text-xs font-bold tracking-wider text-blue-600 uppercase flex items-center gap-1.5 mb-3 select-none">
+          <LockIcon className="size-3 text-blue-600" />
           <span>{featureGroupTitle}</span>
         </h3>
-        <ul className="space-y-2.5 text-sm">
+        <ul className="space-y-2.5 text-[15px]">
           {features.map((feature) => {
             const text = feature.text;
             const locked = feature.locked || false;
@@ -107,9 +133,9 @@ function PlanCard({
             return (
               <li key={text} className="flex gap-2.5 items-start">
                 {locked ? (
-                  <X className="mt-0.5 size-4 shrink-0 text-red-500" aria-hidden="true" />
+                  <XIcon className="mt-0.5 size-4 shrink-0 text-red-500" aria-hidden="true" />
                 ) : (
-                  <Check className="mt-0.5 size-4 shrink-0 text-gray-900" aria-hidden="true" />
+                  <CheckIcon className="mt-0.5 size-4 shrink-0 text-gray-900" aria-hidden="true" />
                 )}
                 <span className={locked ? "text-gray-400 font-normal" : "text-gray-500"}>
                   {text}
@@ -125,12 +151,17 @@ function PlanCard({
 
 export function PricingPlans() {
   const { data: state, error: loadError, isPending } = useQuery(billingQueryOptions);
+  const { data: quota, isPending: isQuotaPending } = useQuery(creationQuotaQueryOptions);
+  const { data: session } = useQuery(sessionQueryOptions);
   const [discountCode, setDiscountCode] = useState("");
   const [pending, setPending] = useState<"checkout" | "portal" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-
   async function go(kind: "checkout" | "portal") {
     setActionError(null);
+    if (kind === "checkout" && session?.user && !session.user.emailVerified) {
+      setActionError("Please verify your email address before upgrading to Pro.");
+      return;
+    }
     setPending(kind);
     try {
       window.location.href =
@@ -148,7 +179,7 @@ export function PricingPlans() {
       <Notice>{loadError instanceof Error ? loadError.message : "Failed to load billing."}</Notice>
     );
 
-  if (isPending || !state) {
+  if (isPending || isQuotaPending || !state || !quota) {
     return (
       <div className="grid gap-5 sm:grid-cols-2">
         <div className="h-96 rounded-2xl bg-gray-100 animate-pulse border border-gray-200/50" />
@@ -183,6 +214,9 @@ export function PricingPlans() {
 
   const proCardFeatures = proFeatures(state.proCredits).map((feature) => ({ text: feature }));
 
+  const isFreeActive = state.planId === "free";
+  const freeCreditsLimit = isFreeActive ? quota.limit : (quota.signupCredits ?? 0);
+
   return (
     <div className="font-geist">
       <div className="grid gap-5 sm:grid-cols-2">
@@ -191,19 +225,19 @@ export function PricingPlans() {
           name="Free"
           tagline="Everything you need to try it properly."
           creditsInfo={{
-            amount: `${state.credits.limit} credits / period`,
-            detail: `= ${state.credits.limit} AI diagram generations`,
-            helperText: `Fixed allowance of ${state.credits.limit} credits`,
+            amount: `${freeCreditsLimit} credits lifetime`,
+            detail: `= ${freeCreditsLimit} AI diagram generations`,
+            helperText: `Fixed allowance of ${freeCreditsLimit} credits`,
           }}
           price="$0"
-          priceSuffix="per month, free forever"
+          priceSuffix="free forever"
           featureGroupTitle="Core Capabilities"
           features={freeCardFeatures}
         >
           {isPro ? (
             <button
               disabled
-              className="w-full flex items-center justify-center h-9 rounded-xl border border-gray-100 bg-gray-50 text-xs font-semibold text-gray-400 select-none cursor-default"
+              className="w-full flex items-center justify-center h-9 rounded-xl border border-gray-100 bg-gray-50 text-sm font-semibold text-gray-400 select-none cursor-default"
             >
               Downgrade Locked
             </button>
@@ -211,11 +245,11 @@ export function PricingPlans() {
             <div className="flex flex-col gap-2">
               <button
                 disabled
-                className="w-full flex items-center justify-center h-9 rounded-xl border border-gray-200 bg-gray-50 text-xs font-semibold text-gray-500 select-none cursor-default"
+                className="w-full flex items-center justify-center h-9 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold text-gray-500 select-none cursor-default"
               >
                 Current Plan
               </button>
-              <p className="text-[10px] text-gray-400 font-semibold mt-1 text-center truncate">
+              <p className="text-xs text-gray-400 font-semibold mt-1 text-center truncate">
                 {allowance}
               </p>
             </div>
@@ -232,7 +266,9 @@ export function PricingPlans() {
             helperText: "Renewing monthly allowance",
           }}
           price="$8"
+          originalPrice="$10"
           priceSuffix="/ month, cancel anytime"
+          priceBadge="Early Launch Discount"
           featureGroupTitle="Advanced Capabilities"
           features={proCardFeatures}
           highlighted
@@ -242,21 +278,21 @@ export function PricingPlans() {
               <button
                 onClick={() => void go("portal")}
                 disabled={pending !== null}
-                className="w-full flex items-center justify-center gap-1.5 h-9 rounded-xl border border-gray-200 hover:bg-gray-50 text-xs font-semibold text-gray-700 transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-center gap-1.5 h-9 rounded-xl border border-gray-200 hover:bg-gray-50 text-sm font-semibold text-gray-700 transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {pending === "portal" ? (
-                  <Loader2 className="size-4 animate-spin text-gray-900" aria-hidden="true" />
+                  <CircleNotchIcon className="size-4 animate-spin text-gray-900" />
                 ) : (
                   <>
-                    <ExternalLink className="size-3.5 text-gray-900" aria-hidden="true" />
+                    <ArrowSquareOutIcon className="size-3.5 text-gray-900" />
                     Manage billing
                   </>
                 )}
               </button>
               <div className="flex flex-col gap-0.5 mt-1 text-center">
-                <p className="text-[10px] text-gray-400 font-semibold truncate">{allowance}</p>
+                <p className="text-xs text-gray-400 font-semibold truncate">{allowance}</p>
                 {sub && (
-                  <p className="text-[9px] text-gray-400 font-medium">
+                  <p className="text-xs text-gray-400 font-medium">
                     {sub.cancelAtPeriodEnd ? "Access ends" : "Renews"} on{" "}
                     {new Date(sub.currentPeriodEnd).toLocaleDateString()}
                   </p>
@@ -265,6 +301,11 @@ export function PricingPlans() {
             </div>
           ) : (
             <div className="space-y-3">
+              {session?.user && !session.user.emailVerified && (
+                <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200/80 rounded-xl p-3 leading-relaxed font-semibold">
+                  Please verify your email address first to upgrade to Pro.
+                </p>
+              )}
               <input
                 type="text"
                 value={discountCode}
@@ -274,18 +315,18 @@ export function PricingPlans() {
                 autoComplete="off"
                 spellCheck={false}
                 disabled={pending !== null}
-                className="w-full px-3 py-2 border border-gray-200 rounded-xl text-xs outline-none focus:border-gray-400 transition font-geist text-gray-900"
+                className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm outline-none focus:border-gray-400 transition font-geist text-gray-900"
               />
               <HeroButton
                 text="Unlock Pro Access"
-                color="blue"
+                color="orange"
                 onClick={() => void go("checkout")}
-                disabled={pending !== null}
-                className="w-full justify-center h-9 text-xs font-semibold rounded-xl cursor-pointer"
+                disabled={pending !== null || (session?.user && !session.user.emailVerified)}
+                className="w-full justify-center h-9 text-sm font-semibold rounded-xl cursor-pointer"
               />
               {pending === "checkout" && (
                 <div className="flex justify-center pt-1">
-                  <Loader2 className="size-4 animate-spin text-blue-600" />
+                  <CircleNotchIcon className="size-4 animate-spin text-orange" />
                 </div>
               )}
             </div>

--- a/apps/client/src/components/settings/SubscriptionStatus.tsx
+++ b/apps/client/src/components/settings/SubscriptionStatus.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import { Meter } from "@cloudflare/kumo";
+import { billingQueryOptions } from "#/lib/api/billing-client";
+import { creationQuotaQueryOptions } from "#/lib/api/usage-client";
+
+export function SubscriptionStatus() {
+  const {
+    data: state,
+    isPending: isBillingPending,
+    error: billingError,
+  } = useQuery(billingQueryOptions);
+  const {
+    data: quota,
+    isPending: isQuotaPending,
+    error: quotaError,
+  } = useQuery(creationQuotaQueryOptions);
+
+  if (
+    isBillingPending ||
+    isQuotaPending ||
+    billingError ||
+    quotaError ||
+    !state ||
+    !quota ||
+    !state.billingEnabled
+  ) {
+    return null;
+  }
+
+  const { remaining, limit, resetAt } = quota;
+  const planName = state.planId === "pro" ? "Pro Plan" : "Free Plan";
+  const isPro = state.planId === "pro";
+  const periodText = resetAt ? "this month" : "lifetime";
+
+  // Calculate percentage remaining (0 to 100)
+  const percentage = limit > 0 ? Math.min(100, Math.max(0, (remaining / limit) * 100)) : 0;
+
+  // Determine progress bar color based on percentage remaining
+  let indicatorColor = "bg-red-500";
+  if (percentage >= 80) {
+    indicatorColor = "bg-green-500";
+  } else if (percentage >= 20) {
+    indicatorColor = "bg-yellow-500";
+  }
+
+  return (
+    <div className="mb-6 rounded-2xl border border-gray-200/80 bg-white p-6 font-geist shadow-sm">
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <div>
+          <span className="text-[10px] font-bold tracking-wider text-gray-400 uppercase select-none">
+            Active Subscription
+          </span>
+          <h2 className="text-lg font-bold text-gray-900 mt-0.5">{planName}</h2>
+        </div>
+        {isPro && (
+          <span className="rounded-full bg-orange px-2.5 py-0.5 text-[10px] font-bold text-white uppercase tracking-wider shadow-sm">
+            Active
+          </span>
+        )}
+      </div>
+
+      <div className="w-full">
+        <Meter
+          value={percentage}
+          label="Generation Allowance"
+          customValue={`${remaining} of ${limit} remaining ${periodText}`}
+          trackClassName="bg-gray-100"
+          indicatorClassName={indicatorColor}
+        />
+      </div>
+
+      {resetAt && (
+        <p className="text-[10px] text-gray-400 font-semibold mt-3">
+          Usage resets on {new Date(resetAt).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/settings/profile.tsx
+++ b/apps/client/src/components/settings/profile.tsx
@@ -40,6 +40,32 @@ export function SettingsProfileCard() {
   const { data: session, isPending } = useQuery(sessionQueryOptions);
   const user = session?.user;
   const [signOutPending, setSignOutPending] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+
+  async function resendVerification() {
+    if (!user?.email) return;
+    setResendLoading(true);
+    try {
+      const { error } = await authClient.sendVerificationEmail({
+        email: user.email,
+        callbackURL: window.location.origin + "/app",
+      });
+      if (error) throw new Error(error.message ?? "Failed to send email.");
+      toastManager.add({
+        title: "Verification email sent",
+        description: "Please check your inbox (and spam folder) for the verification link.",
+        variant: "success",
+      });
+    } catch (err: unknown) {
+      toastManager.add({
+        title: "Failed to send email",
+        description: err instanceof Error ? err.message : "Something went wrong",
+        variant: "error",
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  }
 
   async function signOut() {
     setSignOutPending(true);
@@ -101,34 +127,57 @@ export function SettingsProfileCard() {
   const email = user.email?.trim() || null;
 
   return (
-    <div className="mb-6 flex items-center gap-3 rounded-lg border border-gray-200/80 bg-white p-4 font-geist">
-      {user.image ? (
-        <img
-          src={user.image}
-          alt=""
-          width={48}
-          height={48}
-          className="size-12 shrink-0 rounded-full border border-gray-200/50 object-cover"
+    <div className="flex flex-col gap-4 mb-6">
+      <div className="flex items-center gap-3 rounded-lg border border-gray-200/80 bg-white p-4 font-geist">
+        {user.image ? (
+          <img
+            src={user.image}
+            alt=""
+            width={48}
+            height={48}
+            className="size-12 shrink-0 rounded-full border border-gray-200/50 object-cover"
+          />
+        ) : (
+          <div className="grid size-12 shrink-0 place-items-center rounded-full bg-gray-900 text-sm font-semibold text-white uppercase">
+            {getInitials(displayName)}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-[15px] font-semibold text-gray-900 body-font">
+            {displayName}
+          </p>
+          {email && email !== displayName ? (
+            <p className="truncate text-sm text-gray-500 mt-0.5">{email}</p>
+          ) : null}
+          <p className="mt-1 text-xs text-gray-400">Signed in · Default workspace</p>
+        </div>
+        <CustomButton
+          type="button"
+          disabled={signOutPending}
+          onClick={() => void signOut()}
+          text={signOutPending ? "Signing out…" : "Log out"}
+          className="shrink-0 text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700 font-geist"
         />
-      ) : (
-        <div className="grid size-12 shrink-0 place-items-center rounded-full bg-gray-900 text-sm font-semibold text-white uppercase">
-          {getInitials(displayName)}
+      </div>
+
+      {!user.emailVerified && (
+        <div className="rounded-xl border border-yellow-200 bg-yellow-50/50 p-4 text-sm text-yellow-800 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 font-geist">
+          <div>
+            <p className="font-semibold text-yellow-900">Verify your email address</p>
+            <p className="text-xs text-yellow-700 mt-0.5 leading-relaxed">
+              Verify your email to unlock your full Free Plan allowance of 25 lifetime credits
+              instead of the guest limit of 3.
+            </p>
+          </div>
+          <CustomButton
+            type="button"
+            disabled={resendLoading}
+            onClick={() => void resendVerification()}
+            text={resendLoading ? "Sending..." : "Resend Link"}
+            className="shrink-0 text-yellow-800 border-yellow-300 hover:bg-yellow-100 hover:text-yellow-900 font-geist"
+          />
         </div>
       )}
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[15px] font-semibold text-gray-900 body-font">{displayName}</p>
-        {email && email !== displayName ? (
-          <p className="truncate text-sm text-gray-500 mt-0.5">{email}</p>
-        ) : null}
-        <p className="mt-1 text-xs text-gray-400">Signed in · Default workspace</p>
-      </div>
-      <CustomButton
-        type="button"
-        disabled={signOutPending}
-        onClick={() => void signOut()}
-        text={signOutPending ? "Signing out…" : "Log out"}
-        className="shrink-0 text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700 font-geist"
-      />
     </div>
   );
 }

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -7,19 +7,21 @@ type ButtonProps = React.ComponentProps<typeof Button> & {
 
 const heroColors: Record<string, string> = {
   blue: "!bg-blue-600 hover:!bg-blue-700",
+  orange: "!bg-orange hover:!bg-orange/90",
   "red-500": "!bg-red-500 hover:!bg-red-600",
 };
 
 export const HeroButton = ({ text, className, color, ...props }: ButtonProps) => {
   const colorClass = heroColors[color] ?? "!bg-blue-600 hover:!bg-blue-700";
+  const isOrange = color === "orange";
+  const shadowClass = isOrange
+    ? "shadow-[0_1px_2px_0_rgba(14,18,27,0.24),0_0_0_1px_#ff4a2c,inset_0_1px_0_0_rgba(255,255,255,0.12)]"
+    : "shadow-[0_1px_2px_0_rgba(14,18,27,0.24),0_0_0_1px_#288DFF,inset_0_1px_0_0_rgba(255,255,255,0.12)]";
+
   return (
     <Button
       variant="primary"
-      className={cn(
-        `${colorClass} rounded-xl px-6 py-3 text-white`,
-        "shadow-[0_1px_2px_0_rgba(14,18,27,0.24),0_0_0_1px_#288DFF,inset_0_1px_0_0_rgba(255,255,255,0.12)]",
-        className,
-      )}
+      className={cn(`${colorClass} rounded-xl px-6 py-3 text-white`, shadowClass, className)}
       {...props}
     >
       {text}

--- a/apps/client/src/lib/api/billing-client.ts
+++ b/apps/client/src/lib/api/billing-client.ts
@@ -6,7 +6,6 @@ export type BillingState = {
   billingEnabled: boolean;
   planId: "guest" | "free" | "pro";
   credits: { limit: number; resetAt: string | null };
-  /** Pro's monthly allowance, read from the `plan` table so copy can't go stale. */
   proCredits: number;
   subscription: {
     status: "pending" | "active" | "on_hold" | "cancelled" | "failed" | "expired";

--- a/apps/client/src/lib/api/index.ts
+++ b/apps/client/src/lib/api/index.ts
@@ -4,3 +4,4 @@ export * from "./project-file-sync";
 export * from "./session";
 export * from "./threads";
 export * from "./billing-client";
+export * from "./usage-client";

--- a/apps/client/src/lib/api/usage-client.ts
+++ b/apps/client/src/lib/api/usage-client.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getDevFetch } from "../dev-telemetry";
+import type { CreationQuota } from "../types/errors";
+
+const BASE_URL = import.meta.env.VITE_SERVER_URL || "";
+const devFetch = getDevFetch();
+
+export async function getCreationQuota(): Promise<CreationQuota | null> {
+  const response = await devFetch(`${BASE_URL.replace(/\/$/, "")}/api/usage/creation-quota`, {
+    credentials: "include",
+  });
+  if (!response.ok) return null;
+  const data = (await response.json()) as { quota: CreationQuota | null };
+  return data.quota;
+}
+
+export const creationQuotaQueryOptions = queryOptions({
+  queryKey: ["usage", "creation-quota"],
+  queryFn: getCreationQuota,
+  staleTime: 10 * 1000, // 10 seconds
+});

--- a/apps/client/src/lib/utils/offline-storage.ts
+++ b/apps/client/src/lib/utils/offline-storage.ts
@@ -62,6 +62,12 @@ export function clearPendingFiles(): Promise<void> {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   try {
     const request = indexedDB.open("OpenDiagramOffline", 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains("pending")) {
+        db.createObjectStore("pending");
+      }
+    };
     request.onsuccess = () => {
       const db = request.result;
       const tx = db.transaction("pending", "readwrite");

--- a/apps/client/src/routes/_protected/pricing.tsx
+++ b/apps/client/src/routes/_protected/pricing.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PricingPlans } from "#/components/settings/PricingPlans";
 import { SettingsHeader } from "#/components/settings/profile";
+import { CaretDownIcon } from "@phosphor-icons/react";
 
 export const Route = createFileRoute("/_protected/pricing")({
   component: PricingPageRoute,
@@ -24,44 +25,67 @@ function PricingPageRoute() {
 
         <div className="mt-16 border-t border-gray-200/80 pt-10">
           <h2 className="pricing-section-title text-gray-900 mb-6">Frequently Asked Questions</h2>
-          <div className="grid gap-6 sm:grid-cols-2">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2 font-geist">
-                How do credits work?
-              </h3>
-              <p className="text-xs leading-relaxed text-gray-500 font-geist">
+          <div className="flex flex-col gap-3 w-full">
+            <details className="group border border-gray-200/80 rounded-xl bg-white p-4 transition-all [&_summary::-webkit-details-marker]:hidden">
+              <summary className="flex items-center justify-between cursor-pointer list-none">
+                <span className="text-[15px] font-semibold text-gray-900 font-geist">
+                  How do credits work?
+                </span>
+                <span className="transition duration-200 group-open:rotate-180 text-gray-500">
+                  <CaretDownIcon className="size-4" />
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-gray-500 font-geist border-t border-gray-100 pt-3">
                 Your allowance resets at the start of each billing cycle. If you hit your limit, you
                 can instantly plug in your own OpenAI/Gemini API key in Settings to continue
                 designing for free.
               </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2 font-geist">
-                Can I cancel my subscription?
-              </h3>
-              <p className="text-xs leading-relaxed text-gray-500 font-geist">
+            </details>
+
+            <details className="group border border-gray-200/80 rounded-xl bg-white p-4 transition-all [&_summary::-webkit-details-marker]:hidden">
+              <summary className="flex items-center justify-between cursor-pointer list-none">
+                <span className="text-[15px] font-semibold text-gray-900 font-geist">
+                  Can I cancel my subscription?
+                </span>
+                <span className="transition duration-200 group-open:rotate-180 text-gray-500">
+                  <CaretDownIcon className="size-4" />
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-gray-500 font-geist border-t border-gray-100 pt-3">
                 Yes, you can cancel your plan in one click at any time from your settings page. You
                 will retain all Pro features until the end of your current billing period.
               </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2 font-geist">
-                Who handles payments?
-              </h3>
-              <p className="text-xs leading-relaxed text-gray-500 font-geist">
+            </details>
+
+            <details className="group border border-gray-200/80 rounded-xl bg-white p-4 transition-all [&_summary::-webkit-details-marker]:hidden">
+              <summary className="flex items-center justify-between cursor-pointer list-none">
+                <span className="text-[15px] font-semibold text-gray-900 font-geist">
+                  Who handles payments?
+                </span>
+                <span className="transition duration-200 group-open:rotate-180 text-gray-500">
+                  <CaretDownIcon className="size-4" />
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-gray-500 font-geist border-t border-gray-100 pt-3">
                 All payments are processed securely by Dodo Payments (our Merchant of Record). We
                 never see, store, or process your raw credit card details.
               </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2 font-geist">
-                Do I need a paid plan to use my own key?
-              </h3>
-              <p className="text-xs leading-relaxed text-gray-500 font-geist">
+            </details>
+
+            <details className="group border border-gray-200/80 rounded-xl bg-white p-4 transition-all [&_summary::-webkit-details-marker]:hidden">
+              <summary className="flex items-center justify-between cursor-pointer list-none">
+                <span className="text-[15px] font-semibold text-gray-900 font-geist">
+                  Do I need a paid plan to use my own key?
+                </span>
+                <span className="transition duration-200 group-open:rotate-180 text-gray-500">
+                  <CaretDownIcon className="size-4" />
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-gray-500 font-geist border-t border-gray-100 pt-3">
                 No, bringing your own AI key is completely free. You can use it to generate
                 unlimited diagrams without ever subscribing to the Pro tier.
               </p>
-            </div>
+            </details>
           </div>
         </div>
       </main>

--- a/apps/client/src/routes/_protected/settings.tsx
+++ b/apps/client/src/routes/_protected/settings.tsx
@@ -3,6 +3,7 @@ import { LockKeyhole } from "lucide-react";
 import { SettingsHeader, SettingsProfileCard } from "#/components/settings/profile";
 import { Providers } from "#/components/settings/providers";
 import { PricingPlans } from "#/components/settings/PricingPlans";
+import { SubscriptionStatus } from "#/components/settings/SubscriptionStatus";
 
 export const Route = createFileRoute("/_protected/settings")({
   component: SettingsPageRoute,
@@ -14,7 +15,7 @@ function SettingsPageRoute() {
       <main className="mx-auto w-full max-w-3xl px-4 py-10">
         <SettingsHeader />
         <SettingsProfileCard />
-
+        <SubscriptionStatus />
         <h1 className="text-2xl font-semibold mb-2 heading-font text-gray-900 mt-10">Plan</h1>
         <p className="mt-1 mb-6 text-sm text-gray-500 body-font">
           Your current allowance, and where to upgrade or cancel.

--- a/apps/client/src/routes/app.tsx
+++ b/apps/client/src/routes/app.tsx
@@ -4,10 +4,11 @@ import { PromptInput } from "#/components/ui/PromptInput";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useKumoToastManager } from "@cloudflare/kumo";
-import { sessionQueryOptions, createProject, createProjectFile } from "#/lib/api";
+import { sessionQueryOptions, createProject, createProjectFile, authClient } from "#/lib/api";
 import { savePendingFiles, clearPendingFiles } from "#/lib/utils";
 import { Sidebar } from "@cloudflare/kumo/components/sidebar";
 import { CheckoutReturn } from "#/components/billing/CheckoutReturn";
+import { CustomButton } from "#/components/ui/button";
 
 const TAGLINE_POOL = [
   "Describe a vibe, get an architecture.",
@@ -30,22 +31,60 @@ const TAGLINE_POOL = [
 export const Route = createFileRoute("/app")({
   validateSearch: (
     search: Record<string, unknown>,
-  ): { checkout?: string; subscription_id?: string; status?: string } => {
+  ): { checkout?: string; subscription_id?: string; status?: string; verified?: string } => {
     return {
       checkout: (search.checkout as string) || undefined,
       subscription_id: (search.subscription_id as string) || undefined,
       status: (search.status as string) || undefined,
+      verified: (search.verified as string) || undefined,
     };
   },
   component: RouteComponent,
 });
-
 function RouteComponent() {
   const navigate = useNavigate();
   const toastManager = useKumoToastManager();
   const { data: session, isPending, error } = useQuery(sessionQueryOptions);
   const isAuthenticated = !isPending && !error && !!session?.user;
   const [tagline, setTagline] = useState("");
+  const { verified } = Route.useSearch();
+  const [resendLoading, setResendLoading] = useState(false);
+
+  async function resendVerification() {
+    if (!session?.user?.email) return;
+    setResendLoading(true);
+    try {
+      const { error } = await authClient.sendVerificationEmail({
+        email: session.user.email,
+        callbackURL: window.location.origin + "/app",
+      });
+      if (error) throw new Error(error.message ?? "Failed to send email.");
+      toastManager.add({
+        title: "Verification email sent",
+        description: "Please check your inbox (and spam folder) for the verification link.",
+        variant: "success",
+      });
+    } catch (err: unknown) {
+      toastManager.add({
+        title: "Failed to send email",
+        description: err instanceof Error ? err.message : "Something went wrong",
+        variant: "error",
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (verified === "1") {
+      toastManager.add({
+        title: "Email verified",
+        description: "Your email has been verified successfully. Welcome to OpenDiagram!",
+        variant: "success",
+      });
+      void navigate({ to: "/app", search: (prev) => ({ ...prev, verified: undefined }) });
+    }
+  }, [verified, toastManager, navigate]);
 
   useEffect(() => {
     const randomPhrase = TAGLINE_POOL[Math.floor(Math.random() * TAGLINE_POOL.length)];
@@ -139,6 +178,24 @@ function RouteComponent() {
 
         {/* Content Workspace */}
         <div className="flex-1 flex flex-col items-center justify-center p-8 bg-gray-50/30 overflow-y-auto">
+          {!isPending && session?.user && !session.user.emailVerified && (
+            <div className="w-full max-w-[680px] mb-6 rounded-xl border border-yellow-200 bg-yellow-50/50 p-4 text-sm text-yellow-800 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 font-geist">
+              <div>
+                <p className="font-semibold text-yellow-900">Verify your email address</p>
+                <p className="text-xs text-yellow-700 mt-0.5 leading-relaxed">
+                  Verify your email to unlock your full Free Plan allowance of 25 lifetime credits
+                  instead of the guest limit of 3.
+                </p>
+              </div>
+              <CustomButton
+                type="button"
+                disabled={resendLoading}
+                onClick={() => void resendVerification()}
+                text={resendLoading ? "Sending..." : "Resend Link"}
+                className="shrink-0 text-yellow-800 border-yellow-300 hover:bg-yellow-100 hover:text-yellow-900 font-geist"
+              />
+            </div>
+          )}
           <div className="w-full max-w-[680px] flex flex-col items-center gap-4 mb-4">
             <div className="flex flex-col gap-3.5 w-full text-center">
               {tagline && (

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -12,6 +12,8 @@
   --font-excalifont: "OD Excalifont", cursive;
   --font-excali: "OD Excalifont", cursive;
   --color-blue: #288dff;
+  --color-orange: #ff4a2c;
+  --color-od-orange: #ff4a2c;
   --color-white: #fff;
   --color-od-ink: #1a1a1a;
   --color-od-ink-faint: rgba(0, 0, 0, 0.5);
@@ -47,7 +49,7 @@ body {
 /* Pricing-specific font classes for higher visual hierarchy */
 .pricing-hero-heading {
   font-family: "Geist", sans-serif;
-  font-size: 36px;
+  font-size: 40px;
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.1;
@@ -55,7 +57,7 @@ body {
 
 .pricing-hero-tagline {
   font-family: "Geist", sans-serif;
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.01em;
   line-height: 1.5;
@@ -63,7 +65,7 @@ body {
 
 .pricing-section-title {
   font-family: "Geist", sans-serif;
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 600;
   letter-spacing: -0.02em;
   line-height: 1.2;

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -137,11 +137,21 @@ billingRoute.post("/checkout", async (c) => {
   }
 
   const [account] = await db
-    .select({ email: user.email, name: user.name })
+    .select({ email: user.email, name: user.name, emailVerified: user.emailVerified })
     .from(user)
     .where(eq(user.id, userId))
     .limit(1);
   if (!account) return c.json({ error: "Unauthorized" }, 401);
+
+  if (!account.emailVerified) {
+    return c.json(
+      {
+        error: "Please verify your email address before upgrading to Pro.",
+        code: "email_unverified",
+      },
+      403,
+    );
+  }
 
   // Applied only for a user who has never completed a sale. Dodo does not enforce
   // this itself (see `mayRedeemDiscount`), so this call is the enforcement.

--- a/packages/auth/src/email/index.ts
+++ b/packages/auth/src/email/index.ts
@@ -14,8 +14,20 @@ function client(): Resend | null {
 
 async function send(to: string, body: EmailBody, idempotencyKey?: string): Promise<void> {
   const mailer = client();
-  if (!mailer) return;
+  const isDev = env.NODE_ENV === "development";
 
+  if (isDev || !mailer) {
+    const url = body.text.match(/https?:\/\/[^\s]+/)?.[0] ?? null;
+    console.log("\n==================================================");
+    console.log(`[EMAIL ${!mailer ? "MOCK" : "DEV"} DELIVERY] to: ${to}`);
+    console.log(`Subject: ${body.subject}`);
+    if (url) {
+      console.log(`Link:    ${url}`);
+    }
+    console.log("==================================================\n");
+  }
+
+  if (!mailer) return;
   // Resend returns errors in-band rather than throwing.
   const { error } = await mailer.emails.send(
     {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -11,9 +11,22 @@ function webOrigin(): string {
   return env.CORS_ORIGIN.split(",")[0]?.trim() ?? env.BETTER_AUTH_URL;
 }
 
-function withCallback(url: string, callbackURL: string): string {
+function withCallback(url: string, defaultCallbackURL: string): string {
   const link = new URL(url);
-  link.searchParams.set("callbackURL", callbackURL);
+  const originalCallback = link.searchParams.get("callbackURL");
+  if (originalCallback) {
+    try {
+      const parsed = new URL(originalCallback);
+      const allowed = env.CORS_ORIGIN.split(",").map((o) => o.trim());
+      if (allowed.includes(parsed.origin)) {
+        const callbackWithVerified = new URL(originalCallback);
+        callbackWithVerified.searchParams.set("verified", "1");
+        link.searchParams.set("callbackURL", callbackWithVerified.toString());
+        return link.toString();
+      }
+    } catch {}
+  }
+  link.searchParams.set("callbackURL", defaultCallbackURL);
   return link.toString();
 }
 
@@ -89,7 +102,7 @@ export function createAuth() {
           name: user.name,
           // Better Auth builds the link against the API origin and defaults its
           // callbackURL to "/", which lands the user on the bare API host.
-          url: withCallback(url, `${webOrigin()}/dashboard?verified=1`),
+          url: withCallback(url, `${webOrigin()}/app?verified=1`),
         });
       },
       // Welcome lands after verification, not at signup: two mails racing in the
@@ -98,7 +111,7 @@ export function createAuth() {
         await sendWelcomeMail({
           to: user.email,
           name: user.name,
-          dashboardUrl: `${webOrigin()}/dashboard`,
+          dashboardUrl: `${webOrigin()}/app`,
           credits: await signupCredits(),
         });
       },


### PR DESCRIPTION
This PR adds email verification and subscription checkout guards to the TanStack client.

### Key Changes
1. **Server-Side Checkout Guard:** Blocks subscription checkouts at  if the user's email is not verified.
2. **Client-Side Billing UX:** Disables the "Unlock Pro Access" CTA and shows an inline alert on the Pro pricing card if the user is unverified.
3. **Resend and Verification UI:** Intercepts client signup to show an in-place manual check verification card before dashboard redirection.
4. **Sign-Up Callback URL:** Fixes the redirect callback to resolve to  on the client origin rather than hardcoded legacy .
5. **Development Email Logging:** Outputs verification and reset links directly to the console when `RESEND_API_KEY` is configured in development mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Pro checkouts for users with unverified emails and adds verification flows across signup, settings, and the app home screen. Users with unverified emails now see an inline warning and a disabled upgrade button instead of starting a checkout.

**New Features**
- Settings and the sidebar dropdown show a subscription status card with credit usage meter and upgrade shortcut.
- The pricing page shows the discounted $8 Pro price ($10 struck through) with an Early Launch Discount badge and FAQ accordions.
- Development mode logs verification and reset links to the console, so email links work without a mail server.

**Bug Fixes**
- Checkout return processing now tracks by subscription id, preventing duplicate success handling.
- Verification links resolve to `/app` on the client origin instead of the hardcoded legacy `/dashboard`.
- Clearing pending offline files now creates the IndexedDB store if it's missing.

<sup>Written for commit 30e0ed6f4878fabac4f8f97077710a3926d89f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/OpenDiagram/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

